### PR TITLE
Use 32b eval internally

### DIFF
--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -1,11 +1,11 @@
 /// Save search parameters in a single module
 /// Used to simplify engine testing and future tuning.
 
-pub type Eval = i16;
+pub type Eval = i32;
 pub const MAX_DEPTH: usize = 128; // max depth to search at
-pub const INFINITY: Eval = 30001; // score upper bound
-pub const MATE: Eval = 30000; // mate in 0 moves
-pub const MATE_IN_PLY: Eval = MATE - MAX_DEPTH as i16; // mate in x moves
+pub const INFINITY: Eval = 32001; // score upper bound
+pub const MATE: Eval = 32000; // mate in 0 moves
+pub const MATE_IN_PLY: Eval = MATE - MAX_DEPTH as Eval; // mate in x moves
 
 pub const HISTORY_LOWER_LIMIT: usize = 3; // minimum depth at which history updates happen
 


### PR DESCRIPTION
Use 32b values for eval internally, while still keeping values within 16b bounds. Avoids risking overflows and relaxes INFINITY score. Functionally neutral.

ELO   | 2.45 +- 4.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 13328 W: 3353 L: 3259 D: 6716

Bench: 8395228