### PR TITLE
Use more of the time increment

### DIFF
--- a/src/engine/clock.rs
+++ b/src/engine/clock.rs
@@ -128,11 +128,11 @@ impl Clock {
                     let eight = 0.8 * time as f64;
 
                     let opt_time = (scale * time as f64).min(eight);
-                    (opt_time, (5. * opt_time).min(eight))
+                    (opt_time, (5.0 * opt_time).min(eight))
                 } else {
-                    let total = ((time / 20) + (inc / 2)) as f64;
+                    let total = ((time / 20) + (inc * 3 / 4)) as f64;
 
-                    (0.6 * total, (2. * total).min(time as f64))
+                    (0.6 * total, (2.0 * total).min(time as f64))
                 };
 
                 (


### PR DESCRIPTION
[STC:](https://chess.swehosting.se/test/2035/)
ELO      | 5.77 +- 4.28 (95%)
SPRT    | 8.0+0.08s Threads=1 Hash=16MB
LLR       | 3.02 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 12288 W: 3096 L: 2892 D: 6300

[LTC:](https://chess.swehosting.se/test/2040/)
ELO   | 6.33 +- 4.58 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 10098 W: 2403 L: 2219 D: 5476