### PR TITLE
TT null move

### DIFF
--- a/src/chess/board.rs
+++ b/src/chess/board.rs
@@ -317,7 +317,7 @@ impl Board {
     /// Makes (legal) move on the board
     /// Supplying illegal moves will lead to illegal board states.
     pub fn make_move(&self, m: Move) -> Board {
-        let mut new = self.clone();
+        let mut new = *self;
         let (src, tgt) = (m.get_src(), m.get_tgt());
         let piece = self.piece_at(src); // must exist
         let move_type = m.get_type();
@@ -379,7 +379,7 @@ impl Board {
 
     /// Make move with NNUE accumulator increments
     pub fn make_move_nnue(&self, m: Move, nnue_state: &mut Box<NNUEState>) -> Board {
-        let mut new = self.clone();
+        let mut new = *self;
         let (src, tgt) = (m.get_src(), m.get_tgt());
         let piece = self.piece_at(src);
         let move_type = m.get_type();
@@ -448,7 +448,7 @@ impl Board {
 
     /// Makes the null move on the board, giving the turn to the opponent
     pub fn make_null(&self) -> Board {
-        let mut new = self.clone();
+        let mut new = *self;
         new.side = !self.side;
         new.hash.toggle_side();
 

--- a/src/engine/clock.rs
+++ b/src/engine/clock.rs
@@ -128,11 +128,11 @@ impl Clock {
                     let eight = 0.8 * time as f64;
 
                     let opt_time = (scale * time as f64).min(eight);
-                    (opt_time, (5. * opt_time).min(eight))
+                    (opt_time, (5.0 * opt_time).min(eight))
                 } else {
-                    let total = ((time / 20) + (inc / 2)) as f64;
+                    let total = ((time / 20) + (inc * 3 / 4)) as f64;
 
-                    (0.6 * total, (2. * total).min(time as f64))
+                    (0.6 * total, (2.0 * total).min(time as f64))
                 };
 
                 (

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -235,8 +235,6 @@ impl Position {
         // Probe tt for eval and best move (for pv, only cutoff at leaves)
         let tt_move = match info.tt.probe(self.board.hash) {
             Some(entry) => {
-                let tt_move = entry.get_move();
-
                 if entry.get_depth() >= depth {
                     let tt_eval = entry.get_eval(info.ply);
                     let tt_flag = entry.get_flag();
@@ -253,7 +251,7 @@ impl Position {
                     }
                 }
 
-                Some(tt_move)
+                entry.get_move()
             }
 
             None => None,
@@ -421,10 +419,10 @@ impl Position {
 
             if eval > best_eval {
                 best_eval = eval;
-                best_move = m;
-
+                
                 if eval > alpha {
                     alpha = eval;
+                    best_move = m;
                 }
 
                 if eval >= beta {
@@ -610,9 +608,13 @@ impl<'a> SearchInfo<'a> {
             // move "sanity" check, since a hash collision is possible
             let move_list = board.gen_moves::<true>();
 
-            if move_list.moves.contains(&tt_move) {
-                board = board.make_move(tt_move);
-                print!(" {tt_move}");
+            if let Some(m) = tt_move {
+                if move_list.moves.contains(&m) {
+                    board = board.make_move(m);
+                    print!(" {m}");
+                } else {
+                    break;
+                }
             } else {
                 break;
             }

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -418,8 +418,8 @@ impl Position {
                 best_eval = eval;
                 
                 if eval > alpha {
-                    alpha = eval;
                     best_move = m;
+                    alpha = eval;
                 }
 
                 if eval >= beta {
@@ -527,9 +527,9 @@ impl Position {
 
             if eval > best_eval {
                 best_eval = eval;
-                best_move = m;
-
+                
                 if eval > alpha {
+                    best_move = m;
                     alpha = eval;
                 }
 
@@ -541,7 +541,7 @@ impl Position {
         }
 
         // Save to TT if we at least improved on the static eval.
-        if !info.stop && best_move != NULL_MOVE {
+        if !info.stop {
             let tt_flag = if best_eval >= beta {
                 TTFlag::Lower
             } else if best_eval > old_alpha {

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -329,9 +329,6 @@ impl Position {
 
         for (move_count, (m, s)) in move_list.enumerate() {
             let start_nodes = info.nodes;
-            if move_count == 0 {
-                best_move = m;
-            }
 
             self.make_move(m, info);
             info.tt.prefetch(self.board.hash); // prefetch next hash

--- a/src/engine/tt.rs
+++ b/src/engine/tt.rs
@@ -81,8 +81,12 @@ impl TTField {
     }
 
     /// Returns best move
-    pub fn get_move(&self) -> Move {
-        self.best_move
+    pub fn get_move(&self) -> Option<Move> {
+        if self.best_move != NULL_MOVE {
+            Some(self.best_move)
+        } else {
+            None
+        }
     }
 
     /// Gets eval while normalizing mate scores
@@ -238,12 +242,20 @@ impl TT {
             || ((old.flag != TTFlag::Exact && (flag == TTFlag::Exact || depth >= old.depth as usize))
             || (old.flag == TTFlag::Exact && flag == TTFlag::Exact && depth > old.depth as usize))
         {
+            // Normalize eval to node distance
             let eval = if eval >= MATE_IN_PLY {
                 (eval + ply as Eval) as i16
             } else if eval <= -MATE_IN_PLY {
                 (eval - ply as Eval) as i16
             } else {
                 eval as i16
+            };
+
+            // Don't overwrite best moves with null moves
+            let best_move = if best_move != NULL_MOVE {
+                best_move
+            } else {
+                old.best_move
             };
 
             let new = TTField {

--- a/src/tools/merge.rs
+++ b/src/tools/merge.rs
@@ -53,7 +53,7 @@ impl<'a> QuicklySortableString<'a> {
 impl<'a> PartialEq for QuicklySortableString<'a> {
     fn eq(&self, other: &Self) -> bool {
         self.hash == other.hash
-            && &self.string[self.view.clone()] == &other.string[other.view.clone()]
+            && self.string[self.view.clone()] == other.string[other.view.clone()]
     }
 }
 
@@ -119,7 +119,7 @@ pub fn merge<P1: AsRef<Path>>(input_dir: P1) -> Result<(), Box<dyn Error>> {
 
     // Deduplicate each individual chunk and add it to the heap
     let mut files = BinaryHeap::new();
-    for chunk in indices.chunks(CHUNK_SIZE).into_iter() {
+    for chunk in indices.chunks(CHUNK_SIZE) {
         let mut data = chunk.to_vec();
         data.sort_unstable();
         data.dedup();
@@ -172,7 +172,7 @@ pub fn merge<P1: AsRef<Path>>(input_dir: P1) -> Result<(), Box<dyn Error>> {
     );
 
     // Write final deduplicated data to output file.
-    let mut output = BufWriter::new(File::create(out.clone())?);
+    let mut output = BufWriter::new(File::create(out)?);
     let write_time = std::time::Instant::now();
     for fen in &data {
         writeln!(output, "{}", fen.as_str())?;


### PR DESCRIPTION
Improve handling of NULL_MOVE in TT, and avoid saving moves to the TT until we start improving alpha.

[STC](https://chess.swehosting.se/test/2115/):
ELO   | 3.54 +- 2.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 27696 W: 6857 L: 6575 D: 14264