### PR TITLE
TT static eval

### DIFF
--- a/src/engine/clock.rs
+++ b/src/engine/clock.rs
@@ -8,7 +8,7 @@ use std::{
     sync::Arc,
 };
 
-use crate::chess::{square::*, moves::*};
+use crate::chess::{moves::*, square::*};
 
 #[derive(Clone, Debug)]
 pub enum TimeControl {
@@ -207,9 +207,10 @@ impl Clock {
                 // At the start, we scale the opt time based on how many nodes were dedicated
                 // to searching the best move.
                 let opt_scale = if best_move != NULL_MOVE && nodes != 0 {
-                    let bm_nodes = self.node_count[best_move.get_src() as usize][best_move.get_tgt() as usize];
+                    let bm_nodes =
+                        self.node_count[best_move.get_src() as usize][best_move.get_tgt() as usize];
                     let bm_fraction = bm_nodes as f64 / nodes as f64;
-                    
+
                     // Scale factor from Ethereal, scale between 50% and 240%
                     (0.4 + (1.0 - bm_fraction) * 2.0).max(0.5)
                 } else {

--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -2,7 +2,7 @@
 /// Used to simplify engine testing and future tuning.
 
 pub type Eval = i32;
-pub const MAX_DEPTH: usize = 128; // max depth to search at
+pub const MAX_DEPTH: usize = 127; // max depth to search at
 pub const INFINITY: Eval = 32001; // score upper bound
 pub const MATE: Eval = 32000; // mate in 0 moves
 pub const MATE_IN_PLY: Eval = MATE - MAX_DEPTH as Eval; // mate in x moves

--- a/src/engine/tt.rs
+++ b/src/engine/tt.rs
@@ -24,32 +24,43 @@ pub enum TTFlag {
 /// normalize them to the root-distance, while in the tt they are normalized to node-distance
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Debug, Hash, Default)]
 pub struct TTField {
-    key: u64,        // 8B
-    flag: TTFlag,    // 1B -- only the rightmost 3 bits are actually of note
-    best_move: Move, // 2B
-    eval: i16,       // 2B
-    depth: u8,       // 1B
-    age: u8,         // 1B
+    key: u64,         // 64b
+    flag: TTFlag,     //  2b
+    best_move: Move,  // 16b
+    eval: i16,        // 16b
+    static_eval: i16, // 16b
+    depth: u8,        //  7b
+    age: u8,          //  7b
 }
 
 // Masks for the data field
-const DEPTH_OFFSET: u64 = 8;
-const EVAL_OFFSET: u64 = 16;
-const MOVE_OFFSET: u64 = 32;
-const FLAG_OFFSET: u64 = 48;
-const AGE_MASK: u64 = 0x00000000000000FF; // first byte
-const DEPTH_MASK: u64 = 0x000000000000FF00; // second byte
-const EVAL_MASK: u64 = 0x00000000FFFF0000; // third/fourth byte
-const MOVE_MASK: u64 = 0x0000FFFF00000000; // fifth/sixth byte
+// 00000000 00000000 00000000 00000000 00000000 00000000 00000000 01111111 -- AGE
+// 00000000 00000000 00000000 00000000 00000000 00000000 00111111 10000000 -- DEPTH
+// 00000000 00000000 00000000 00000000 00000000 00000000 11000000 00000000 -- FLAG
+// 00000000 00000000 00000000 00000000 11111111 11111111 00000000 00000000 -- MOVE
+// 00000000 00000000 11111111 11111111 00000000 00000000 00000000 00000000 -- SEARCH RESULT
+// 11111111 11111111 00000000 00000000 00000000 00000000 00000000 00000000 -- STATIC EVAL
+const DEPTH_OFFSET: u64 = 7;
+const FLAG_OFFSET: u64 = 14;
+const MOVE_OFFSET: u64 = 16;
+const SEARCH_OFFSET: u64 = 32;
+const EVAL_OFFSET: u64 = 48;
+
+const AGE_MASK: u64 = 0x7F;
+const DEPTH_MASK: u64 = 0x3F80;
+const FLAG_MASK: u64 = 0xC000;
+const MOVE_MASK: u64 = 0xFFFF0000;
+const SEARCH_MASK: u64 = 0xFFFF00000000;
 
 /// Convert from external field to compressed internal
 impl From<TTField> for (u64, u64) {
     fn from(field: TTField) -> Self {
         let data: u64 = field.age as u64
             | (field.depth as u64) << DEPTH_OFFSET
-            | (field.eval as u16 as u64) << EVAL_OFFSET
+            | (field.flag as u64) << FLAG_OFFSET
             | (field.best_move.0 as u64) << MOVE_OFFSET
-            | (field.flag as u64) << FLAG_OFFSET;
+            | (field.eval as u16 as u64) << SEARCH_OFFSET
+            | (field.static_eval as u16 as u64) << EVAL_OFFSET;
 
         (field.key ^ data, data)
     }
@@ -60,9 +71,10 @@ impl From<(u64, u64)> for TTField {
     fn from((key, data): (u64, u64)) -> Self {
         TTField {
             key,
-            flag: unsafe { transmute((data >> FLAG_OFFSET) as u8) },
+            flag: unsafe { transmute(((data & FLAG_MASK) >> FLAG_OFFSET) as u8) },
             best_move: Move(((data & MOVE_MASK) >> MOVE_OFFSET) as u16),
-            eval: ((data & EVAL_MASK) >> EVAL_OFFSET) as i16,
+            eval: ((data & SEARCH_MASK) >> SEARCH_OFFSET) as i16,
+            static_eval: (data >> EVAL_OFFSET) as i16,
             depth: ((data & DEPTH_MASK) >> DEPTH_OFFSET) as u8,
             age: (data & AGE_MASK) as u8,
         }
@@ -96,17 +108,17 @@ fn to_search(eval: i16, ply: usize) -> Eval {
 
 impl TTField {
     /// Returns entry depth
-    pub fn get_depth(&self) -> usize {
+    pub fn get_depth(self) -> usize {
         self.depth as usize
     }
 
     /// Returns entry flag
-    pub fn get_flag(&self) -> TTFlag {
+    pub fn get_flag(self) -> TTFlag {
         self.flag
     }
 
     /// Returns best move
-    pub fn get_move(&self) -> Option<Move> {
+    pub fn get_move(self) -> Option<Move> {
         if self.best_move != NULL_MOVE {
             Some(self.best_move)
         } else {
@@ -114,9 +126,14 @@ impl TTField {
         }
     }
 
-    /// Gets eval while normalizing mate scores
-    pub fn get_eval(&self, ply: usize) -> Eval {
+    /// Gets search evaluation while normalizing mate scores
+    pub fn get_eval(self, ply: usize) -> Eval {
         to_search(self.eval, ply)
+    }
+
+    /// Gets the static evaluation of the position
+    pub fn get_static_eval(self) -> Eval {
+        self.static_eval as Eval
     }
 }
 
@@ -200,7 +217,7 @@ impl TT {
 
     /// Increase current age. Entries with older age will be overwritten more easily.
     pub fn increment_age(&mut self) {
-        self.age = self.age.wrapping_add(1);
+        self.age = (self.age + 1) & 0b01111111; // 7 bit age
     }
 
     /// Prefetch a cache line containing the entry for the given hash
@@ -240,12 +257,14 @@ impl TT {
     /// Conditions are explained here:
     /// https://stackoverflow.com/questions/37782131/chess-extracting-the-principal-variation-from-the-transposition-table
     #[rustfmt::skip]
+    #[allow(clippy::too_many_arguments)]
     pub fn insert(
         &self,
         key: ZHash,
         flag: TTFlag,
         best_move: Move,
         eval: Eval,
+        static_eval: Eval,
         depth: usize,
         ply: usize
     ) {
@@ -253,12 +272,12 @@ impl TT {
         let old_slot = unsafe { self.table.get_unchecked(tt_index) };
         let old  = old_slot.read_unchecked();
 
-        if  self.age > old.age  // always replace old entries
-            || old.depth == 0  // always replace qsearch/empty entries
+        if  self.age != old.age // always replace entries with a different age
+            || old.depth == 0   // always replace qsearch/empty entries
             || ((old.flag != TTFlag::Exact && (flag == TTFlag::Exact || depth >= old.depth as usize))
             || (old.flag == TTFlag::Exact && flag == TTFlag::Exact && depth > old.depth as usize))
         {
-            // Normalize eval to node distance
+            // Normalize search eval to node distance
             let eval = to_tt(eval, ply);
 
             // Don't overwrite best moves with null moves
@@ -273,6 +292,7 @@ impl TT {
                 flag,
                 best_move,
                 eval,
+                static_eval: static_eval as i16,
                 depth: depth as u8,
                 age: self.age
             };
@@ -300,9 +320,9 @@ mod tests {
         let tt = TT::default();
         let z = ZHash(tt.bitmask);
 
-        tt.insert(z, TTFlag::Exact, Move(1), 100, 1, 0); // insert in empty field
-        tt.insert(z, TTFlag::Exact, Move(1), 100, 2, 0); // replace
-        tt.insert(z, TTFlag::Exact, Move(1), 100, 1, 0); // do not replace
+        tt.insert(z, TTFlag::Exact, Move(1), 100, 100, 1, 0); // insert in empty field
+        tt.insert(z, TTFlag::Exact, Move(1), 100, 100, 2, 0); // replace
+        tt.insert(z, TTFlag::Exact, Move(1), 100, 100, 1, 0); // do not replace
 
         let target1 = tt.probe(z).unwrap();
         let target2 = tt.probe(ZHash(8));
@@ -317,8 +337,8 @@ mod tests {
         tt.resize(1);
 
         // 65537 is 2^16 + 1, so it will collide with 1. checksum should prevent reading
-        tt.insert(ZHash(65537), TTFlag::Exact, NULL_MOVE, 100, 1, 0); // insert field 1
-        tt.insert(ZHash(1), TTFlag::Exact, NULL_MOVE, 100, 2, 0); // insert field 2 in same slot as field 1, replacing it
+        tt.insert(ZHash(65537), TTFlag::Exact, NULL_MOVE, 100, 100, 1, 0); // insert field 1
+        tt.insert(ZHash(1), TTFlag::Exact, NULL_MOVE, 100, 100, 2, 0); // insert field 2 in same slot as field 1, replacing it
 
         let new = tt.probe(ZHash(65537)); // check no match on first hash
         assert!(new.is_none());


### PR DESCRIPTION
Use the newly freed up TT space to fit the static eval and use it in both normal and qsearch.

[STC](https://chess.swehosting.se/test/2167/):
ELO  | 25.86 +- 10.69 (95%)
SPRT | 8.0+0.08s Threads=1 Hash=16MB
LLR | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 1952 W: 541 L: 396 D: 1015