### PR TITLE
Update best_move on Fail High

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -119,7 +119,7 @@ impl Position {
                 break;
             }
 
-            let eval = self.aspiration_window(&mut info, result.eval, d);
+            let eval = self.aspiration_window(&mut info, &mut result.best_move, result.eval, d);
 
             if !info.stop {
                 result.best_move = info.best_move;
@@ -138,7 +138,13 @@ impl Position {
 
     /// Aspiration Window loop
     /// Run searches on progressively wider windows until we find a value within the window.
-    fn aspiration_window(&mut self, info: &mut SearchInfo, prev: Eval, mut depth: usize) -> Eval {
+    fn aspiration_window(
+        &mut self,
+        info: &mut SearchInfo,
+        best_move: &mut Move,
+        prev: Eval,
+        mut depth: usize
+    ) -> Eval {
         let base_depth = depth;
 
         // Setup aspiration window when searching a sufficient depth
@@ -168,6 +174,9 @@ impl Position {
                 if eval.abs() < MATE_IN_PLY && depth > 1 {
                     depth -= 1;
                 }
+
+                // Short circuit saving the best move when failing high
+                *best_move = info.best_move;
             } else {
                 // Search within window, success
                 return eval;


### PR DESCRIPTION
[STC](https://chess.swehosting.se/test/2196/):
ELO   | 5.46 +- 4.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 13416 W: 3496 L: 3285 D: 6635