### PR TITLE
Remove Delta Pruning in QS

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -184,7 +184,7 @@ impl Position {
 
             // Widen window, fully reopen when it's too wide
             delta += delta / 2;
-            if delta >= QS_DELTA_MARGIN {
+            if delta >= BIG_DELTA {
                 alpha = -INFINITY;
                 beta = INFINITY;
             }
@@ -559,7 +559,7 @@ impl Position {
         if !in_check {
             alpha = alpha.max(stand_pat);
 
-            if stand_pat >= beta || stand_pat + QS_DELTA_MARGIN < alpha {
+            if stand_pat >= beta {
                 return stand_pat;
             }
         }

--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -38,8 +38,8 @@ pub const LMP_BASE: usize = 4; // lmp move count at depth = 0
 pub const ASPIRATION_THRESHOLD: usize = 5; // depth at which windows are reduced
 pub const ASPIRATION_WINDOW: Eval = 25; // aspiration window width
 
-pub const QS_DELTA_MARGIN: Eval = 1100; // highest queen value possible
 pub const QS_FUTILITY_MARGIN: Eval = 200; // overhead we allow for captures in qs
+pub const BIG_DELTA: Eval = 1100; // highest queen value possible
 
 pub const PIECE_VALUES: [Eval; 12] = [
     // piece values for static evaluations


### PR DESCRIPTION
[STC](https://chess.swehosting.se/test/2239/):
ELO   | 2.93 +- 2.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 46880 W: 12180 L: 11784 D: 22916