### PR TITLE
QS TT move

### DIFF
--- a/src/engine/position.rs
+++ b/src/engine/position.rs
@@ -66,19 +66,12 @@ impl Default for Position {
 }
 
 impl Position {
-    /// Generate a sorted list of captures
-    pub fn generate_captures(&self, sorter: &MoveSorter) -> MoveList {
-        let mut move_list = self.board.gen_moves::<CAPTURES>();
-
-        sorter.score_captures(&self.board, &mut move_list);
-        move_list
-    }
-
-    /// Generate a sorted list of moves
-    pub fn generate_moves(&self, ply: usize, sorter: &MoveSorter) -> MoveList {
+    /// Generate and sort either all moves or only captures in a position.
+    /// In case of only captures, ply is superfluous.
+    pub fn generate_moves<const QUIETS: bool>(&self, ply: usize, sorter: &MoveSorter) -> MoveList {
         let mut move_list = self.board.gen_moves::<QUIETS>();
 
-        sorter.score_moves(&self.board, ply, &mut move_list);
+        sorter.score_moves::<QUIETS>(&self.board, ply, &mut move_list);
         move_list
     }
 


### PR DESCRIPTION
Sorter refactor adding support for variable SEE threshold and using the TT move in QS. It did not pass prog bounds but I will merge anyway.

[STC](https://chess.swehosting.se/test/2386/):
```
ELO   | 0.51 +- 2.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 34512 W: 8822 L: 8771 D: 16919
```