### PR TITLE
Singular Extensions

### DIFF
--- a/src/engine/move_sorter.rs
+++ b/src/engine/move_sorter.rs
@@ -143,7 +143,7 @@ impl MoveSorter {
     }
 }
 
-const TT_SCORE: i32 = 400;
+pub const TT_SCORE: i32 = 400;
 
 pub const GOOD_CAPTURE: i32 = 100;
 const EP_SCORE: i32 = GOOD_CAPTURE + 10;

--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -14,6 +14,8 @@ pub const LMR_LOWER_LIMIT: usize = 2; // stop applying lmr near leaves
 pub const LMR_BASE: f32 = 0.75; // increase to reduce every move more
 pub const LMR_FACTOR: f32 = 2.0; // increase to reduce less further in the movelist
 
+pub const SE_LOWER_LIMIT: usize = 8; // stop applying SE near leaves
+
 pub const RFP_THRESHOLD: usize = 8; // depth at which rfp kicks in
 pub const RFP_MARGIN: Eval = 130; // multiplier for eval safety margin for rfp cutoffs
 pub const RFP_IMPROVING_MARGIN: Eval = 50; // multiplier for improving flag


### PR DESCRIPTION
Implement the simplest form of singular extensions (only extend by a single ply, no multi-cut). Also includes some non-functional refactoring for retrieving the static evaluation.

[STC](https://chess.swehosting.se/test/2451/):
```
ELO   | 11.25 +- 6.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 4976 W: 1237 L: 1076 D: 2663
https://chess.swehosting.se/test/2451/
```