### PR TITLE
SEE pruning

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -381,7 +381,10 @@ impl Position {
         let mut searched_quiets = Vec::with_capacity(20);
 
         let lmp_count = LMP_BASE + (depth * depth);
-        let see_margin = SEE_QUIET_MARGIN * depth as Eval;
+        let see_margins = [
+            SEE_CAPTURE_MARGIN * (depth * depth) as Eval,
+            SEE_QUIET_MARGIN * depth as Eval
+        ];
 
         for (move_count, (m, s)) in move_list.enumerate() {
             // Skip SE excluded move
@@ -392,12 +395,11 @@ impl Position {
             let start_nodes = info.nodes;
             let is_quiet = m.get_type().is_quiet();
 
-            // SEE pruning for quiet moves
+            // SEE pruning for captures and quiets
             if best_eval > -MATE_IN_PLY
-                && is_quiet
                 && depth <= SEE_THRESHOLD
                 && s < GOOD_CAPTURE
-                && !self.board.see(m, see_margin)
+                && !self.board.see(m, see_margins[is_quiet as usize])
             {
                 continue;
             };

--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -38,6 +38,7 @@ pub const LMP_THRESHOLD: usize = 8; // depth at which late move pruning kicks in
 pub const LMP_BASE: usize = 4; // lmp move count at depth = 0
 
 pub const SEE_THRESHOLD: usize = 9;
+pub const SEE_CAPTURE_MARGIN: Eval = -20; // threshold for see pruning for captures
 pub const SEE_QUIET_MARGIN: Eval = -65;   // threshold for see pruning for quiets
 
 pub const ASPIRATION_THRESHOLD: usize = 5; // depth at which windows are reduced

--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -37,6 +37,9 @@ pub const EFP_MARGIN: Eval = 90; // multiplier for eval bonus margin for efp
 pub const LMP_THRESHOLD: usize = 8; // depth at which late move pruning kicks in
 pub const LMP_BASE: usize = 4; // lmp move count at depth = 0
 
+pub const SEE_THRESHOLD: usize = 9;
+pub const SEE_QUIET_MARGIN: Eval = -65;   // threshold for see pruning for quiets
+
 pub const ASPIRATION_THRESHOLD: usize = 5; // depth at which windows are reduced
 pub const ASPIRATION_WINDOW: Eval = 25; // aspiration window width
 


### PR DESCRIPTION
Skip both quiets and captures which fall short of a depth-dependent SEE threshold. Values are a more conservative version of those from Ethereal.

Firstly only for quiets:

[STC](https://chess.swehosting.se/test/2486/):
```
ELO   | 8.50 +- 5.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 6872 W: 1651 L: 1483 D: 3738
```

Then also pruning captures:

[STC](https://chess.swehosting.se/test/2489/):
```
ELO   | 18.03 +- 8.62 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 2816 W: 708 L: 562 D: 1546
```