### PR TITLE
Fix conthist

### DIFF
--- a/src/engine/move_sorter.rs
+++ b/src/engine/move_sorter.rs
@@ -135,10 +135,9 @@ impl MoveSorter {
         const FUH: bool = false;
         if let Some((counter_move, piece)) = self.counter {
             self.update_double::<CMH>(m, counter_move, piece, bonus, &searched);
-
-            if let Some((followup_move, piece)) = self.followup {
-                self.update_double::<FUH>(m, followup_move, piece, bonus, &searched);
-            }
+        }
+        if let Some((followup_move, piece)) = self.followup {
+            self.update_double::<FUH>(m, followup_move, piece, bonus, &searched);
         }
     }
 }
@@ -230,13 +229,13 @@ impl MoveSorter {
             let prev_tgt = counter_move.get_tgt() as usize;
 
             score += self.counter_moves[piece as usize][prev_tgt][src][tgt];
+        }
 
-            // followup move
-            if let Some((followup_move, piece)) = self.followup {
-                let prev_tgt = followup_move.get_tgt() as usize;
+        // followup move
+        if let Some((followup_move, piece)) = self.followup {
+            let prev_tgt = followup_move.get_tgt() as usize;
 
-                score += self.followup_moves[piece as usize][prev_tgt][src][tgt];
-            }
+            score += self.followup_moves[piece as usize][prev_tgt][src][tgt];
         }
 
         HISTORY_OFFSET + score

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -741,7 +741,7 @@ impl<'a> SearchInfo<'a> {
     /// Push a null move to the search stack
     pub fn push_null(&mut self) {
         self.search_stack[self.ply] = (NULL_MOVE, Piece::WP, self.ply_from_null);
-        self.sorter.followup = None;
+        self.sorter.followup = self.sorter.counter;
         self.sorter.counter = None;
 
         self.ply += 1;
@@ -752,13 +752,20 @@ impl<'a> SearchInfo<'a> {
     /// Pop a move from the search stack
     pub fn pop_move(&mut self) {
         self.ply -= 1;
-        let (_, _, old_ply) = self.search_stack[self.ply];
+        self.ply_from_null = self.search_stack[self.ply].2;
 
-        self.ply_from_null = old_ply;
-        self.sorter.counter = self.sorter.followup;
-        if self.ply_from_null > 1 {
+        if self.ply > 0 && self.search_stack[self.ply - 1].0 != NULL_MOVE {
+            let (m, p, _) = self.search_stack[self.ply - 1];
+            self.sorter.counter = Some((m, p));
+        } else {
+            self.sorter.counter = None;
+        }
+        
+        if self.ply > 1 && self.search_stack[self.ply - 2].0 != NULL_MOVE {
             let (m, p, _) = self.search_stack[self.ply - 2];
             self.sorter.followup = Some((m, p));
+        } else {
+            self.sorter.followup = None;
         }
     }
 


### PR DESCRIPTION
Fix the way Counter/Followup moves are determined while moving up and down the search stack and stop zero-ing out the followup move after a null move.

[STC-REG](https://chess.swehosting.se/test/2505/):
```
ELO   | 1.58 +- 3.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 17616 W: 3884 L: 3804 D: 9928
```