### PR TITLE
Fix hist score

### DIFF
--- a/src/engine/move_sorter.rs
+++ b/src/engine/move_sorter.rs
@@ -64,7 +64,7 @@ impl MoveSorter {
     /// Discussed here:
     /// http://www.talkchess.com/forum3/viewtopic.php?f=7&t=76540
     fn taper_bonus(bonus: i32, old: i32) -> i32 {
-        old + 16 * bonus - old * bonus / 512
+        old + bonus - (old * bonus.abs()) / 16_384
     }
 
     fn add_bonus(&mut self, m: Move, side: usize, bonus: i32) {
@@ -127,7 +127,6 @@ impl MoveSorter {
 
         // history bonus is Stockfish's "gravity"
         let bonus = min(depth * depth, 400) as i32;
-
         self.update_history(m, bonus, side as usize, &searched);
 
         // countermove and followup history

--- a/src/engine/move_sorter.rs
+++ b/src/engine/move_sorter.rs
@@ -1,5 +1,3 @@
-use std::cmp::min;
-
 use crate::chess::{board::*, move_list::*, moves::*, piece::*, square::*};
 use crate::engine::search_params::*;
 
@@ -60,11 +58,11 @@ impl Default for MoveSorter {
 
 /// Sorter updates
 impl MoveSorter {
-    /// Taper history so that it's bounded to 32 * 512 = 16384 (and -16384)
+    /// Taper history so that it's bounded to 8 * 2048 = +/-16384
     /// Discussed here:
     /// http://www.talkchess.com/forum3/viewtopic.php?f=7&t=76540
     fn taper_bonus(bonus: i32, old: i32) -> i32 {
-        old + bonus - (old * bonus.abs()) / 16_384
+        old + 8 * bonus - (old * bonus.abs()) / 2048
     }
 
     fn add_bonus(&mut self, m: Move, side: usize, bonus: i32) {
@@ -126,7 +124,8 @@ impl MoveSorter {
         }
 
         // history bonus is Stockfish's "gravity"
-        let bonus = min(depth * depth, 400) as i32;
+        let bonus = 400.min(depth * depth) as i32;
+
         self.update_history(m, bonus, side as usize, &searched);
 
         // countermove and followup history

--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -28,7 +28,7 @@ pub const NMP_FACTOR: usize = 4; // increase to reduce more at higher depths
 pub const IIR_LOWER_LIMIT: usize = 4; // stop applying iir near leaves
 
 pub const HLP_THRESHOLD: usize = 2; // depth at which history leaf pruning kicks in
-pub const HLP_MARGIN: i32 = 0; // increase to prune quiets with higher history scores
+pub const HLP_MARGIN: i32 = -5000; // increase to prune quiets with higher history scores
 
 pub const EFP_THRESHOLD: usize = 5; // depth at which extended futility pruning kicks in
 pub const EFP_BASE: Eval = 80; // base eval bonus margin for efp


### PR DESCRIPTION
Fix history scores not saturating properly on the lower bound. 

[STC-REG](https://chess.swehosting.se/test/2515/):
```
ELO   | 6.65 +- 5.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 5960 W: 1356 L: 1242 D: 3362
```