### PR TITLE
Fix MovePick scores

### DIFF
--- a/readme.MD
+++ b/readme.MD
@@ -63,7 +63,7 @@ As of Carp 2.0, NNUE has compltely replaced the old HCE.
 * Fully legal move generation with Fixed Shift Black Magic Bitboards
 * Fail-Hard Negamax + Quiescence
 * Iterative Deepening with Aspiration Windows
-* Move Ordering with Staged sorter:
+* Move Ordering with a staged sorter:
   - MVV-LVA with Threshold Static Exchange Evaluation
   - Killers
   - History / Counter Move History / Followup History

--- a/src/engine/move_picker.rs
+++ b/src/engine/move_picker.rs
@@ -51,10 +51,9 @@ impl<const QUIETS: bool> MovePicker<QUIETS> {
         let stage = if move_list.is_empty() {
             // No moves, either mate or stalemate
             Stage::Done
-        } else if tt_move.is_none()  // no TT move
-            || (!QUIETS && tt_move.is_some_and(|m| m.get_type().is_quiet()))
-        {
-            // quiet TT move in qsearch
+        } else if tt_move.is_none()
+            || (!QUIETS && tt_move.is_some_and(|m| m.get_type().is_quiet())) {
+            // no TT move, or quiet TT move in qsearch
             Stage::ScoreTacticals
         } else {
             Stage::TTMove
@@ -229,7 +228,7 @@ impl<const QUIETS: bool> MovePicker<QUIETS> {
 }
 
 /// Special move scoring
-pub const TT_SCORE: i32 = 1000;
+pub const TT_SCORE: i32 = i32::MAX;
 pub const KILLER1: i32 = 102;
 pub const KILLER2: i32 = 101;
 

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -384,7 +384,7 @@ impl Position {
             // SEE pruning for captures and quiets
             if best_eval > -MATE_IN_PLY
                 && depth <= SEE_THRESHOLD
-                && s < GOOD_TACTICAL
+                && picker.stage > Stage::GoodTacticals
                 && !self.board.see(m, see_margins[is_quiet as usize])
             {
                 move_count += 1;


### PR DESCRIPTION
MovePicker scores for quiets could sometimes exceed GOOD_TACTICAL meaning they were not pruned for SEE.

[STC-REG](https://chess.swehosting.se/test/2532/):
```
ELO   | 0.25 +- 2.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 35448 W: 7844 L: 7818 D: 19786
```