### PR TITLE
Apply lmr reduction/extension for very high histories

### DIFF
--- a/src/engine/move_picker.rs
+++ b/src/engine/move_picker.rs
@@ -241,6 +241,8 @@ const EP_SCORE: i32 = 15; // EP equal to pxp
 
 const UNDERPROMO_SCORE: i32 = i32::MIN; // Underpromotions get the worst score.
 
+pub const HISTORY_MAX: i32 = 49152; // Quiet moves have scores between +- 49152
+
 // Attacker is the row, victim is the column
 #[rustfmt::skip]
 const MVV_LVA: [[i32; PIECE_COUNT]; PIECE_COUNT] = [

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -467,7 +467,15 @@ impl Position {
 
                         r += !pv_node as i32; // reduce more in non-pv nodes
                         r += cutnode as i32;  // reduce more for cutnodes
-                        r -= in_check as i32 + is_check as i32; // reduce less when in check/checking the opponent
+
+                        r -= in_check as i32; // reduce less when in check
+                        r -= is_check as i32; // reduce less when giving check
+
+                        if s > HISTORY_MAX / 2 {
+                            r -= 1; // Reduce less high history moves
+                        } else if s < -HISTORY_MAX / 2 {
+                            r += 1; // Reduce more low history moves
+                        }
 
                         r.clamp(1, (depth - 1) as i32) as usize
                     } else {


### PR DESCRIPTION
Note that this test would have passed [0,3] bounds.

[STC](https://chess.swehosting.se/test/2575/):
```
ELO   | 1.96 +- 1.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.32 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 84896 W: 18963 L: 18484 D: 47449
```