### PR TITLE
Move Bad Captures after Quiets

### DIFF
--- a/src/chess/moves.rs
+++ b/src/chess/moves.rs
@@ -43,9 +43,9 @@ impl MoveType {
         self as usize & 0b0100 != 0
     }
 
-    /// Returns true if the move is either a capture or a queen promotion
-    pub const fn is_good_tactical(self) -> bool {
-        self as usize & 0b1100 == 0b1000 || self as usize & 0b0111 == 0b0111
+    /// Returns true if the move is an underpromotion.
+    pub const fn is_underpromotion(self) -> bool {
+        self.is_promotion() && self as usize & 0b0111 != 0b0111
     }
 
     /// Returns true if the move is a capture (include enpassant)

--- a/src/engine/move_picker.rs
+++ b/src/engine/move_picker.rs
@@ -28,7 +28,7 @@ pub enum Stage {
 ///                            ^ good_tactical_index           ^ bad_tactical_index
 ///
 pub struct MovePicker<const QUIETS: bool> {
-    pub move_list: MoveList,
+    move_list: MoveList,
     scores: [i32; MAX_MOVES],
     index: usize,               // Index used for movelist traversal
     good_tactical_index: usize, // Index of the first non-tactical move

--- a/src/engine/move_picker.rs
+++ b/src/engine/move_picker.rs
@@ -180,10 +180,12 @@ impl<const QUIETS: bool> MovePicker<QUIETS> {
             self.index = self.bad_tactical_index;
         }
 
-        // Yield all tactical moves with a negative SEE (and underpromotions)
+        // Yield all tactical moves with a negative SEE (and underpromotions if not skipping quiets)
         if self.true_stage == Stage::BadTacticals {
             if let Some((m, s)) = self.partial_sort(self.move_list.len()) {
-                return Some((m, s));
+                if !(self.skip_quiets && s == BAD_TACTICAL) {
+                    return Some((m, s));
+                }
             }
 
             self.stage = Stage::Done;

--- a/src/engine/move_picker.rs
+++ b/src/engine/move_picker.rs
@@ -5,36 +5,38 @@ use crate::engine::{search_info::*, search_params::*};
 /// Tacticals include both captures and promotions.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Debug, Hash)]
 pub enum Stage {
+    Init,
     TTMove,
     ScoreTacticals,
     GoodTacticals,
     Killer1,
     Killer2,
-    BadTacticals,
     ScoreQuiets,
     Quiets,
+    BadTacticals,
     Done,
 }
 
 /// MovePicker is an iterator over the move list, yielding moves in order of heuristic value.
 /// Moves are scored as lazily as possible since the move loop usually terminates very quickly.
 ///
-/// In the end, the move list ends up structured as follows, although this is not the same as the
-/// order in which moves are yielded:
+/// In the end, the move list ends up structured as follows:
 ///
-///                                                                  v killer_index
-/// +---------------------------------------------------------------------------------------+
-/// | TT MOVE | GOOD TACTICALS | BAD TACTICALS | KILLER 1 | KILLER 2 | QUIETS | UNDERPROMOS |
-/// +---------------------------------------------------------------------------------------+
-///                                            ^ tactical_index
+///                                                   v quiet_index
+/// +--------------------------------------------------------------------------+
+/// | TT MOVE | GOOD TACTICALS |  KILLER 1 | KILLER 2 | QUIETS | BAD TACTICALS |
+/// +--------------------------------------------------------------------------+
+///                            ^ good_tactical_index           ^ bad_tactical_index
 ///
 pub struct MovePicker<const QUIETS: bool> {
     move_list: MoveList,
     scores: [i32; MAX_MOVES],
-    index: usize,          // Index before which all moves have already been tried
-    tactical_index: usize, // Index of the first non-tactical move
-    killer_index: usize,   // Index of the first non-killer move
-    pub stage: Stage,
+    index: usize,               // Index used for movelist traversal
+    good_tactical_index: usize, // Index of the first non-tactical move
+    bad_tactical_index: usize,  // Index of the first bad tactical move
+    quiet_index: usize,         // Index of the first non-killer quiet move
+    pub stage: Stage,           // Stage we expose externally
+    true_stage: Stage,          // Stage we are actually in
     tt_move: Option<Move>,
     pub skip_quiets: bool,
     see_threshold: Eval,
@@ -48,11 +50,12 @@ impl<const QUIETS: bool> MovePicker<QUIETS> {
         tt_move: Option<Move>,
         see_threshold: i32,
     ) -> MovePicker<QUIETS> {
-        let stage = if move_list.is_empty() {
+        let bad_tactical_index = move_list.len();
+        let true_stage = if move_list.is_empty() {
             // No moves, either mate or stalemate
             Stage::Done
-        } else if tt_move.is_none()
-            || (!QUIETS && tt_move.is_some_and(|m| m.get_type().is_quiet())) {
+        } else if tt_move.is_none() || (!QUIETS && tt_move.is_some_and(|m| m.get_type().is_quiet()))
+        {
             // no TT move, or quiet TT move in qsearch
             Stage::ScoreTacticals
         } else {
@@ -63,9 +66,11 @@ impl<const QUIETS: bool> MovePicker<QUIETS> {
             move_list,
             scores: [0; MAX_MOVES],
             index: 0,
-            tactical_index: 0,
-            killer_index: 0,
-            stage,
+            good_tactical_index: 0,
+            bad_tactical_index,
+            quiet_index: 0,
+            stage: Stage::Init,
+            true_stage,
             tt_move,
             skip_quiets: false,
             see_threshold,
@@ -76,123 +81,131 @@ impl<const QUIETS: bool> MovePicker<QUIETS> {
     /// Note that most of the logic here is "fall through" where a stage may quietly pass without
     /// yielding a move (e.g. all scoring stages)
     pub fn next(&mut self, board: &Board, info: &SearchInfo) -> Option<(Move, i32)> {
-        if self.stage == Stage::Done {
+        if self.true_stage == Stage::Done {
             return None;
         }
 
         // Lazily look for the TT move
-        if self.stage == Stage::TTMove {
-            self.stage = Stage::ScoreTacticals;
+        if self.true_stage == Stage::TTMove {
+            self.true_stage = Stage::ScoreTacticals;
 
             let tt_move = self.tt_move.unwrap(); // We know it's Some
-            if let Some(m) = self.find_pred(self.index, |m| m == tt_move) {
+            if let Some(m) = self.find_pred(self.index, self.move_list.len(), |m| m == tt_move) {
                 self.index += 1;
+                self.stage = Stage::TTMove;
                 return Some((m, TT_SCORE));
             }
         }
 
         // Assign a score to all captures/queen promotions and move them to the front.
-        if self.stage == Stage::ScoreTacticals {
+        if self.true_stage == Stage::ScoreTacticals {
             self.stage = Stage::GoodTacticals;
+            self.true_stage = Stage::GoodTacticals;
             self.score_tacticals(board);
         }
 
-        // Yield all captures/promotions with a positive SEE
-        if self.stage == Stage::GoodTacticals {
-            if let Some((m, s)) = self.partial_sort(self.tactical_index) {
-                if s >= GOOD_TACTICAL {
-                    return Some((m, s));
-                }
-
-                // Re-include the move with bad SEE for later sorting.
-                self.index -= 1;
+        // Yield all captures/queen promotions with a positive SEE
+        if self.true_stage == Stage::GoodTacticals {
+            if let Some((m, s)) = self.partial_sort(self.good_tactical_index) {
+                return Some((m, s));
             }
 
             // In QSearch we implicitly skip all captures with negative SEE and underpromotions.
             if QUIETS {
-                self.stage = Stage::Killer1;
+                self.true_stage = Stage::Killer1;
             } else {
                 self.stage = Stage::Done;
+                self.true_stage = Stage::Done;
                 return None;
             }
         }
 
         // Lazily look for the first killer move (if we are not skipping quiets)
-        if self.stage == Stage::Killer1 {
-            self.killer_index = self.tactical_index; // Killers are after tacticals
-            self.stage = Stage::Killer2;
+        if self.true_stage == Stage::Killer1 {
+            self.quiet_index = self.good_tactical_index; // Killers are after good tacticals
+            self.true_stage = Stage::Killer2;
 
             let k1 = info.killer_moves[info.ply][0];
-            if !self.skip_quiets && k1 != NULL_MOVE {
-                if let Some(m) = self.find_pred(self.killer_index, |m| m == k1) {
-                    self.killer_index += 1;
+            if !self.skip_quiets && k1 != NULL_MOVE && self.tt_move != Some(k1) {
+                let killer = self.find_pred(self.quiet_index, self.bad_tactical_index, |m| m == k1);
+
+                if let Some(m) = killer {
+                    self.stage = Stage::Killer1;
+                    self.quiet_index += 1;
                     return Some((m, KILLER1));
                 }
             }
         }
 
         // Lazily look for the second killer move (if we are not skipping quiets)
-        if self.stage == Stage::Killer2 {
-            self.stage = Stage::BadTacticals;
+        if self.true_stage == Stage::Killer2 {
+            // If we are skipping quiets, we can just move to bad tacticals
+            if !self.skip_quiets {
+                self.true_stage = Stage::ScoreQuiets;
+            } else {
+                self.stage = Stage::BadTacticals;
+                self.true_stage = Stage::BadTacticals;
+                self.index = self.bad_tactical_index;
+            }
 
             let k2 = info.killer_moves[info.ply][1];
-            if !self.skip_quiets && k2 != NULL_MOVE {
-                if let Some(m) = self.find_pred(self.killer_index, |m| m == k2) {
-                    self.killer_index += 1;
+            if !self.skip_quiets && k2 != NULL_MOVE && self.tt_move != Some(k2) {
+                let killer = self.find_pred(self.quiet_index, self.bad_tactical_index, |m| m == k2);
+
+                if let Some(m) = killer {
+                    self.stage = Stage::Killer2;
+                    self.quiet_index += 1;
                     return Some((m, KILLER2));
                 }
             }
         }
 
-        // Yield all captures/queen promotions with a negative SEE
-        if self.stage == Stage::BadTacticals {
-            if let Some((m, s)) = self.partial_sort(self.tactical_index) {
-                return Some((m, s + BAD_TACTICAL));
-            }
-
-            // If we are skipping quiets, we are done.
-            if !self.skip_quiets {
-                self.stage = Stage::ScoreQuiets;
-            } else {
-                self.stage = Stage::Done;
-                return None;
-            }
-        }
-
-        // Assign a score to all quiet moves/underpromotions
-        if self.stage == Stage::ScoreQuiets {
+        // Assign a history score to all quiet moves
+        if self.true_stage == Stage::ScoreQuiets {
             self.stage = Stage::Quiets;
-            self.index = self.killer_index; // Skip over the killers
+            self.true_stage = Stage::Quiets;
             self.score_quiets(board.side, info);
         }
 
         // Yield all quiet moves/underpromotions
-        if self.stage == Stage::Quiets {
+        if self.true_stage == Stage::Quiets {
             if !self.skip_quiets {
-                if let Some((m, s)) = self.partial_sort(self.move_list.len()) {
+                if let Some((m, s)) = self.partial_sort(self.bad_tactical_index) {
                     return Some((m, s));
                 }
             }
 
+            self.true_stage = Stage::BadTacticals;
+            self.stage = Stage::BadTacticals;
+            self.index = self.bad_tactical_index;
+        }
+
+        // Yield all tactical moves with a negative SEE (and underpromotions)
+        if self.true_stage == Stage::BadTacticals {
+            if let Some((m, s)) = self.partial_sort(self.move_list.len()) {
+                return Some((m, s));
+            }
+
             self.stage = Stage::Done;
+            self.true_stage = Stage::Done;
         }
 
         None
     }
 
-    /// Yield the first move satisfying the given predicate.
+    /// Yield the first move satisfying the given predicate within the range [start, end)
     /// Searches from the given starting index and swaps the move back to it.
-    fn find_pred(&mut self, index: usize, pred: impl Fn(Move) -> bool) -> Option<Move> {
-        if index == self.move_list.len() {
+    fn find_pred(&mut self, start: usize, end: usize, pred: impl Fn(Move) -> bool) -> Option<Move> {
+        if start >= end {
             return None;
         }
 
         // Look for a move satisfying the predicate
-        for i in index..self.move_list.len() {
+        for i in start..end {
             let m = self.move_list.moves[i];
 
             if pred(m) {
-                self.move_list.moves.swap(i, index);
+                self.move_list.moves.swap(i, start);
                 return Some(m);
             }
         }
@@ -204,7 +217,8 @@ impl<const QUIETS: bool> MovePicker<QUIETS> {
     /// This is done over the range [self.index, end], with end excluded.
     ///
     /// O(n^2) sorting but takes advantage of early cutoffs which shouldn't require a full list
-    /// sort. On top of that, we are exploiting the cache friendliness of linear memory access.
+    /// sort. On top of that, we are exploiting the cache friendliness of linear memory access,
+    /// and are usually limited to pretty short ranges.
     fn partial_sort(&mut self, end: usize) -> Option<(Move, i32)> {
         if self.index == end {
             return None;
@@ -232,14 +246,12 @@ pub const TT_SCORE: i32 = i32::MAX;
 pub const KILLER1: i32 = GOOD_TACTICAL + 2;
 pub const KILLER2: i32 = GOOD_TACTICAL + 1;
 
-/// Tactical scoring: [10 - 70] + [1.000.000 - 2.000.000]
+/// Tactical scoring: [10 - 70] + [1.000.000-2.000.000]
 pub const GOOD_TACTICAL: i32 = 2_000_000;
 pub const BAD_TACTICAL: i32 = 1_000_000;
 
 const PROMO_SCORE: i32 = 70; // Queen promotions have best MVV-LVA value, but still less than good tacticals
 const EP_SCORE: i32 = 15; // EP equal to pxp
-
-const UNDERPROMO_SCORE: i32 = i32::MIN; // Underpromotions get the worst score.
 
 pub const HISTORY_MAX: i32 = 49152; // Quiet moves have scores between +- 49152
 
@@ -263,28 +275,29 @@ const MVV_LVA: [[i32; PIECE_COUNT]; PIECE_COUNT] = [
 
 /// Score a single tactical move. These moves are either captures or queen promotions.
 fn score_tactical(m: Move, see_threshold: Eval, board: &Board) -> i32 {
-    let mt = m.get_type();
-
-    // Enpassant/QueenCapPromo are always good
-    match mt {
-        MoveType::EnPassant => return GOOD_TACTICAL + EP_SCORE,
-        MoveType::QueenCapPromo => return GOOD_TACTICAL + PROMO_SCORE,
-        _ => (),
+    // Underpromotions get the worst score
+    if m.get_type().is_underpromotion() {
+        return BAD_TACTICAL;
     }
 
-    // Our move can either be a simple queen promotion or a normal capture.
-    let mut score = if mt == MoveType::QueenPromotion {
-        PROMO_SCORE
-    } else {
-        let attacker = board.piece_at(m.get_src()) as usize;
-        let victim = board.piece_at(m.get_tgt()) as usize;
+    // Enpassant/QueenCapPromo are always good
+    let mut score = match m.get_type() {
+        MoveType::EnPassant => return GOOD_TACTICAL + EP_SCORE,
+        MoveType::QueenCapPromo => return GOOD_TACTICAL + PROMO_SCORE,
+        MoveType::QueenPromotion => PROMO_SCORE,
+        _ => {
+            let attacker = board.piece_at(m.get_src()) as usize;
+            let victim = board.piece_at(m.get_tgt()) as usize;
 
-        MVV_LVA[attacker][victim]
+            MVV_LVA[attacker][victim]
+        }
     };
 
     // Give a bonus to moves with positive SEE
     if board.see(m, see_threshold) {
-        score += GOOD_TACTICAL
+        score += GOOD_TACTICAL;
+    } else {
+        score += BAD_TACTICAL;
     }
 
     score
@@ -292,18 +305,30 @@ fn score_tactical(m: Move, see_threshold: Eval, board: &Board) -> i32 {
 
 /// Implement ordering functions
 impl<const QUIETS: bool> MovePicker<QUIETS> {
-    /// Assign a score to each capture/queen promotion and move them to the front of the move list.
+    /// Assign a score to each tactical move.
+    /// Good tacticals are moved to the front of the list, bad tacticals to the back.
     fn score_tacticals(&mut self, board: &Board) {
-        self.tactical_index = self.index;
+        let mut i = self.index;
+        self.good_tactical_index = self.index;
 
-        for i in self.index..self.move_list.len() {
+        while i < self.bad_tactical_index {
             let m = self.move_list.moves[i];
-            let mt = m.get_type();
 
-            if mt.is_good_tactical() {
-                self.move_list.moves.swap(i, self.tactical_index);
-                self.scores[self.tactical_index] = score_tactical(m, self.see_threshold, board);
-                self.tactical_index += 1;
+            if !QUIETS || !m.get_type().is_quiet() {
+                let score = score_tactical(m, self.see_threshold, board);
+
+                if score >= GOOD_TACTICAL {
+                    self.move_list.moves.swap(i, self.good_tactical_index);
+                    self.scores[self.good_tactical_index] = score;
+                    self.good_tactical_index += 1;
+                    i += 1;
+                } else {
+                    self.bad_tactical_index -= 1;
+                    self.move_list.moves.swap(i, self.bad_tactical_index);
+                    self.scores[self.bad_tactical_index] = score;
+                }
+            } else {
+                i += 1;
             }
         }
     }
@@ -311,14 +336,12 @@ impl<const QUIETS: bool> MovePicker<QUIETS> {
     /// Assign a score to each quiet move.
     /// Given the minimum score to underpromotions and a history score to the rest.
     fn score_quiets(&mut self, side: Color, info: &SearchInfo) {
-        for i in self.index..self.move_list.len() {
+        self.index = self.quiet_index; // skip over killers
+
+        for i in self.index..self.bad_tactical_index {
             let m = self.move_list.moves[i];
 
-            self.scores[i] = if m.get_type().is_promotion() {
-                UNDERPROMO_SCORE
-            } else {
-                info.score_history(m, side)
-            }
+            self.scores[i] = info.score_history(m, side);
         }
     }
 }
@@ -372,10 +395,10 @@ mod tests {
         assert_eq!(moves[0].0, tt_move);
         assert_eq!(moves[1].0, good_cap);
         assert_eq!(moves[5].0, k1);
-        assert_eq!(moves[6].0, bad_promo);
-        assert_eq!(moves[7].0, good_quiet);
-        assert_eq!(moves[27].0, bad_quiet);
-        assert_eq!(moves[28].1, i32::MIN);
+        assert_eq!(moves[6].0, good_quiet);
+        assert_eq!(moves[26].0, bad_quiet);
+        assert_eq!(moves[27].0, bad_promo);
+        assert_eq!(moves[28].1, BAD_TACTICAL);
     }
 
     #[test]

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -379,11 +379,7 @@ impl Position {
             let is_quiet = m.get_type().is_quiet();
 
             // Quiet move pruning
-            if !pv_node
-                && !in_check
-                && !picker.skip_quiets
-                && best_eval > -MATE_IN_PLY
-            {
+            if !pv_node && !in_check && !picker.skip_quiets && best_eval > -MATE_IN_PLY {
                 // History leaf pruning
                 // Below a certain depth, prune negative history moves in non-pv nodes
                 if is_quiet && depth <= HLP_THRESHOLD && s < HLP_MARGIN {

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -420,7 +420,7 @@ impl Position {
             // Failing below the reduced beta means no other move is any good.
             let mut ext_depth = depth;
 
-            if possible_singularity && picker.stage == Stage::TTMove {
+            if possible_singularity && s == TT_SCORE {
                 let tt_eval = tt_entry.unwrap().get_eval(info.ply); // Can't panic
                 let se_beta = (tt_eval - 2 * depth as Eval).max(-INFINITY);
                 let se_depth = (depth - 1) / 2; // depth is always > 0 so this is safe

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -171,7 +171,7 @@ impl Position {
         mut alpha: Eval,
         mut beta: Eval,
         mut depth: usize,
-        cutnode: bool
+        cutnode: bool,
     ) -> Eval {
         if info.stop || !info.clock.mid_check() {
             info.stop = true;
@@ -185,10 +185,6 @@ impl Position {
             info.seldepth = 0;
         } else {
             info.seldepth = info.seldepth.max(info.ply);
-        }
-
-        if !pv_node && alpha != beta - 1 {
-            println!("DANGER");
         }
 
         // Check extension
@@ -384,7 +380,7 @@ impl Position {
 
             // SEE pruning for captures and quiets
             if best_eval > -MATE_IN_PLY
-                && depth <= SEE_THRESHOLD
+                && depth <= SEE_PRUNING_THRESHOLD
                 && picker.stage > Stage::GoodTacticals
                 && !self.board.see(m, see_margins[is_quiet as usize])
             {
@@ -392,20 +388,17 @@ impl Position {
                 continue;
             };
 
-            self.make_move(m, info);
-            info.tt.prefetch(self.board.hash); // prefetch next hash
-
-            // After make move, in_check tells us if this move gives check
-            let is_check = self.king_in_check();
-
             // Quiet move pruning
-            if !pv_node && !in_check && is_quiet && !is_check && alpha >= -MATE_IN_PLY {
-                let mut prune = false;
-
+            if !pv_node
+                && !in_check
+                && !picker.skip_quiets
+                && picker.stage <= Stage::Quiets
+                && alpha > -MATE_IN_PLY
+            {
                 // History leaf pruning
                 // Below a certain depth, prune negative history moves in non-pv nodes
                 if depth <= HLP_THRESHOLD && s < HLP_MARGIN {
-                    prune = true;
+                    picker.skip_quiets = true;
                 }
 
                 let lmr_depth = depth - lmr_reduction(depth, move_count).min(depth);
@@ -413,47 +406,37 @@ impl Position {
                 // Extended Futility pruning
                 // Below a certain depth, prune moves which will most likely not improve alpha
                 let efp_margin = EFP_BASE + EFP_MARGIN * (lmr_depth as Eval);
-                if !prune && lmr_depth <= EFP_THRESHOLD && stand_pat + efp_margin < alpha {
-                    prune = true;
+                if lmr_depth <= EFP_THRESHOLD && stand_pat + efp_margin < alpha {
+                    picker.skip_quiets = true;
                 }
 
                 // Late move pruning
-                if !prune && depth <= LMP_THRESHOLD && move_count >= lmp_count {
-                    prune = true;
-                }
-
-                // even when all moves get pruned, save something to the tt
-                if prune {
-                    self.undo_move(info);
-                    break;
+                if depth <= LMP_THRESHOLD && move_count >= lmp_count {
+                    picker.skip_quiets = true;
                 }
             }
 
             // Singular Extensions (second part):
-            // We perform a verification search excluding the tt move, with a window around beta.
-            // If this search fails below beta, we accept singularity and extend the depth by one.
+            // We perform a verification search excluding the tt move, with a window around se_beta.
+            // Failing below the reduced beta means no other move is any good.
             let mut ext_depth = depth;
 
-            if possible_singularity && s == TT_SCORE {
+            if possible_singularity && picker.stage == Stage::TTMove {
                 let tt_eval = tt_entry.unwrap().get_eval(info.ply); // Can't panic
                 let se_beta = (tt_eval - 2 * depth as Eval).max(-INFINITY);
                 let se_depth = (depth - 1) / 2; // depth is always > 0 so this is safe
 
-                // Revert the line and exclude the possibly singular move
-                self.undo_move(info);
-                info.nodes -= 1;
                 info.excluded[info.ply] = Some(m);
-
                 let eval = self.negamax::<false>(info, se_beta - 1, se_beta, se_depth, cutnode);
-
-                // Reset the line
                 info.excluded[info.ply] = None;
-                self.make_move(m, info);
 
                 if eval < se_beta {
                     ext_depth += 1;
                 }
             }
+
+            self.make_move(m, info);
+            info.tt.prefetch(self.board.hash); // prefetch next hash
 
             // Principal Variation Search + Late Move Reductions
             // Before most searches, we run a "verification" search on a null window to prove it
@@ -464,15 +447,16 @@ impl Position {
                 if depth >= LMR_LOWER_LIMIT && move_count >= LMR_THRESHOLD + pv_node as usize {
                     let r = if is_quiet {
                         let mut r = lmr_reduction(depth, move_count) as i32;
+                        let is_check = self.king_in_check();
 
                         r += !pv_node as i32; // reduce more in non-pv nodes
-                        r += cutnode as i32;  // reduce more for cutnodes
+                        r += cutnode as i32; // reduce more for cutnodes
 
                         r -= in_check as i32; // reduce less when in check
                         r -= is_check as i32; // reduce less when giving check
 
                         if s > HISTORY_MAX / 2 {
-                            r -= 1; // Reduce less high history moves
+                            r -= 1; // Reduce less high history moves/killers
                         } else if s < -HISTORY_MAX / 2 {
                             r += 1; // Reduce more low history moves
                         }
@@ -643,9 +627,7 @@ impl Position {
             // Futility Pruning
             // Avoid searching captures that, even with an extra margin, would not raise alpha
             let move_value = stand_pat + PIECE_VALUES[self.board.get_capture(m) as usize];
-            if !in_check 
-                && !m.get_type().is_promotion()
-                && move_value + QS_FUTILITY_MARGIN < alpha
+            if !in_check && !m.get_type().is_promotion() && move_value + QS_FUTILITY_MARGIN < alpha
             {
                 continue;
             }

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -378,26 +378,15 @@ impl Position {
             let start_nodes = info.nodes;
             let is_quiet = m.get_type().is_quiet();
 
-            // SEE pruning for captures and quiets
-            if best_eval > -MATE_IN_PLY
-                && depth <= SEE_PRUNING_THRESHOLD
-                && picker.stage > Stage::GoodTacticals
-                && !self.board.see(m, see_margins[is_quiet as usize])
-            {
-                move_count += 1;
-                continue;
-            };
-
             // Quiet move pruning
             if !pv_node
                 && !in_check
                 && !picker.skip_quiets
-                && picker.stage <= Stage::Quiets
                 && alpha > -MATE_IN_PLY
             {
                 // History leaf pruning
                 // Below a certain depth, prune negative history moves in non-pv nodes
-                if depth <= HLP_THRESHOLD && s < HLP_MARGIN {
+                if is_quiet && depth <= HLP_THRESHOLD && s < HLP_MARGIN {
                     picker.skip_quiets = true;
                 }
 
@@ -415,6 +404,16 @@ impl Position {
                     picker.skip_quiets = true;
                 }
             }
+
+            // SEE pruning for captures and quiets
+            if best_eval > -MATE_IN_PLY
+                && depth <= SEE_PRUNING_THRESHOLD
+                && picker.stage > Stage::GoodTacticals
+                && !self.board.see(m, see_margins[is_quiet as usize])
+            {
+                move_count += 1;
+                continue;
+            };
 
             // Singular Extensions (second part):
             // We perform a verification search excluding the tt move, with a window around se_beta.

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -382,7 +382,7 @@ impl Position {
             if !pv_node
                 && !in_check
                 && !picker.skip_quiets
-                && alpha > -MATE_IN_PLY
+                && best_eval > -MATE_IN_PLY
             {
                 // History leaf pruning
                 // Below a certain depth, prune negative history moves in non-pv nodes

--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -37,7 +37,7 @@ pub const EFP_MARGIN: Eval = 90; // multiplier for eval bonus margin for efp
 pub const LMP_THRESHOLD: usize = 8; // depth at which late move pruning kicks in
 pub const LMP_BASE: usize = 4; // lmp move count at depth = 0
 
-pub const SEE_THRESHOLD: usize = 9;
+pub const SEE_PRUNING_THRESHOLD: usize = 9; // depth at which see pruning kicks in
 pub const SEE_CAPTURE_MARGIN: Eval = -20; // threshold for see pruning for captures
 pub const SEE_QUIET_MARGIN: Eval = -65; // threshold for see pruning for quiets
 


### PR DESCRIPTION
Move bad SEE tacticals to the back of the movelist and overhaul quiet pruning. Firstly, bad tacticals were moved to the back of the movelist, then in the second test underpromotions were skipped when skipping quiet moves.

[STC](https://chess.swehosting.se/test/2634/):
```
ELO   | 3.76 +- 3.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 22632 W: 5165 L: 4920 D: 12547
```

[STC](https://chess.swehosting.se/test/2686/):
```
ELO   | 3.18 +- 2.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 30936 W: 6889 L: 6606 D: 17441
```