### PR TITLE
No PV TT cutoffs

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -233,18 +233,12 @@ impl Position {
                 let tt_eval = entry.get_eval(info.ply);
 
                 // TT Cutoffs
-                if tt_depth >= depth {
-                    if !ROOT && pv_node && tt_flag == TTFlag::Exact && depth == 1 {
-                        return tt_eval;
-                    }
-
-                    if !pv_node {
-                        match tt_flag {
-                            TTFlag::Exact => return tt_eval,
-                            TTFlag::Lower if tt_eval >= beta => return beta,
-                            TTFlag::Upper if tt_eval <= alpha => return alpha,
-                            _ => (),
-                        }
+                if tt_depth >= depth && !pv_node {
+                    match tt_flag {
+                        TTFlag::Exact => return tt_eval,
+                        TTFlag::Lower if tt_eval >= beta => return beta,
+                        TTFlag::Upper if tt_eval <= alpha => return alpha,
+                        _ => (),
                     }
                 }
 


### PR DESCRIPTION
Don't do cutoffs off TT hits in PV nodes even if we would otherwise drop into quiescence.

[STC](https://chess.swehosting.se/test/2719/):
```
ELO   | 0.64 +- 2.75 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 27320 W: 6107 L: 6057 D: 15156
```