### PR TITLE
No QS FP

### DIFF
--- a/readme.MD
+++ b/readme.MD
@@ -84,7 +84,6 @@ As of Carp 2.0, NNUE has compltely replaced the old HCE.
 * History Leaf Pruning
 * Extended Futility Pruning
 * Late Move Pruning
-* SEE/Futility pruning in QS
 * Singular Extensions
 
 ## Dependencies

--- a/src/engine/nnue/mod.rs
+++ b/src/engine/nnue/mod.rs
@@ -246,8 +246,14 @@ mod tests {
         s2.pop();
 
         for i in 0..HIDDEN {
-            assert_eq!(s1.accumulator_stack[0].white[i], s2.accumulator_stack[0].white[i]);
-            assert_eq!(s1.accumulator_stack[0].black[i], s2.accumulator_stack[0].black[i]);
+            assert_eq!(
+                s1.accumulator_stack[0].white[i],
+                s2.accumulator_stack[0].white[i]
+            );
+            assert_eq!(
+                s1.accumulator_stack[0].black[i],
+                s2.accumulator_stack[0].black[i]
+            );
         }
         assert_eq!(s1.current_acc, s2.current_acc);
     }
@@ -293,8 +299,14 @@ mod tests {
         s1.move_update(b1.piece_at(m.get_src()), m.get_src(), m.get_tgt());
 
         for i in 0..HIDDEN {
-            assert_eq!(s1.accumulator_stack[0].white[i], s2.accumulator_stack[0].white[i]);
-            assert_eq!(s1.accumulator_stack[0].black[i], s2.accumulator_stack[0].black[i]);
+            assert_eq!(
+                s1.accumulator_stack[0].white[i],
+                s2.accumulator_stack[0].white[i]
+            );
+            assert_eq!(
+                s1.accumulator_stack[0].black[i],
+                s2.accumulator_stack[0].black[i]
+            );
         }
     }
 }

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -613,14 +613,6 @@ impl Position {
 
         // The capture picker implicitly prunes bad SEE moves
         while let Some((m, _)) = picker.next(&self.board, info) {
-            // Futility Pruning
-            // Avoid searching captures that, even with an extra margin, would not raise alpha
-            let move_value = stand_pat + PIECE_VALUES[self.board.get_capture(m) as usize];
-            if !in_check && !m.get_type().is_promotion() && move_value + QS_FUTILITY_MARGIN < alpha
-            {
-                continue;
-            }
-
             self.make_move(m, info);
             info.tt.prefetch(self.board.hash); // prefetch next hash
             let eval = -self.quiescence(info, -beta, -alpha);


### PR DESCRIPTION
Yet another simplification actually being elo-positive.

[STC](https://chess.swehosting.se/test/2941/):
```
ELO   | 2.50 +- 3.98 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 13216 W: 3044 L: 2949 D: 7223
```