### PR TITLE
Keep histories between moves

### DIFF
--- a/src/engine/thread.rs
+++ b/src/engine/thread.rs
@@ -88,11 +88,6 @@ impl Thread {
     pub fn advance_ply(&mut self) {
         self.killer_moves = [[NULL_MOVE; 2]; MAX_DEPTH];
 
-        // Remove these to not reinitialize histories every move.
-        self.history = HistoryTable::default();
-        self.counter_moves = DoubleHistoryTable::default();
-        self.followup_moves = DoubleHistoryTable::default();
-
         self.nodes = 0;
         self.clock.last_nodes = 0; // reset SMP worker threads
         self.seldepth = 0;


### PR DESCRIPTION
This should mostly just benefit STC play.

[STC](https://chess.swehosting.se/test/3278/):
```
ELO   | 13.61 +- 7.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 3856 W: 936 L: 785 D: 2135
```