### PR TITLE
Shift killers back between moves

### DIFF
--- a/src/tools/datagen.rs
+++ b/src/tools/datagen.rs
@@ -165,7 +165,7 @@ fn datagen_thread(id: usize, games: usize, tc: TimeControl, path: &Path) {
             }
 
             tt.increment_age();
-            thread.advance_ply();
+            thread.advance_ply(1);
             thread.clock = Clock::new(
                 Arc::new(AtomicBool::new(false)),
                 Arc::new(AtomicU64::new(0)),


### PR DESCRIPTION
Advance the killer move table by 2 ply every move, instead of clearing it. Should have nearly no effect on LTC but it probably considerably speeds up datagen and any really short TC.

[STC](https://chess.swehosting.se/test/3285/):
```
ELO   | 3.18 +- 2.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 30912 W: 6871 L: 6588 D: 17453
```