### PR TITLE
TT Replacement bug fix + policy change

### DIFF
--- a/src/engine/bench.rs
+++ b/src/engine/bench.rs
@@ -64,7 +64,7 @@ pub fn run_benchmark() {
 
     for fen in TEST_POSITIONS {
         let mut position: Position = fen.parse().unwrap();
-        let mut t = Thread::fixed_depth(16);
+        let mut t = Thread::fixed_depth(13);
 
         let start = Instant::now();
         position.iterative_search::<false>(&mut t, &TT::default());

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -219,6 +219,7 @@ impl Position {
                     stand_pat,
                     0,
                     t.ply,
+                    false,
                 );
             }
         };
@@ -469,6 +470,7 @@ impl Position {
                 stand_pat,
                 depth,
                 t.ply,
+                pv_node,
             );
         }
 
@@ -596,6 +598,7 @@ impl Position {
                 stand_pat,
                 0,
                 t.ply,
+                false,
             );
         }
 

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -264,8 +264,13 @@ impl Position {
         }
 
         // Internal Iterative Reduction
-        // When no TT Move is found in any node, apply a 1-ply reduction
-        if !ROOT && tt_move.is_none() && depth >= IIR_LOWER_LIMIT {
+        // Without a TT hit, it's better to do a reduced search to then setup the TT entry for the next
+        // IID iteration.
+        if !ROOT
+            && depth >= IIR_LOWER_LIMIT
+            && !in_singular_search
+            && (tt_entry.is_none() || tt_entry.is_some_and(|e| e.get_flag() == TTFlag::None))
+        {
             depth -= 1;
         }
 

--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -12,6 +12,8 @@ pub const INFINITY: Eval = 32001; // score upper bound
 pub const MATE: Eval = 32000; // mate in 0 moves
 pub const MATE_IN_PLY: Eval = MATE - MAX_DEPTH as Eval; // mate in x moves
 
+pub const TT_REPLACE_OFFSET: usize = 11;
+
 pub const ASPIRATION_LOWER_LIMIT: usize = 5;
 pub const ASPIRATION_WINDOW: Eval = 25;
 pub const BIG_DELTA: Eval = 1100;


### PR DESCRIPTION
Fix a bug where TT entries would keep old best moves even though the position they represent changes, in case the new move being stored was null.
Doing this inadvertedly messed with IIR, actually causing a ~10 elo loss, so to offset the IIR formula was changed to depend on not having a TT hit, instead of not having any TT move. This resulted in the first test which showed neutral results.
On top of this, a different replacement scheme was added to ensure the patch was elo-positive, replacing more aggressively now that the PV is not retrieved from the TT anymore.

[STC](https://chess.swehosting.se/test/3486/):
```
ELO   | 1.34 +- 3.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -0.32 (-2.25, 2.89) [0.00, 5.00]
GAMES | N: 13760 W: 3016 L: 2963 D: 7781
```

[STC](https://chess.swehosting.se/test/3502/):
```
ELO   | 8.76 +- 5.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
GAMES | N: 6384 W: 1493 L: 1332 D: 3559
```