### PR TITLE
Fix repetition detection

### DIFF
--- a/src/engine/position.rs
+++ b/src/engine/position.rs
@@ -149,12 +149,10 @@ impl Position {
     /// Check for repetitions in hash history.
     /// We stop at the first occurrence of the position and consider that a draw.
     fn is_repetition(&self, ply_from_null: usize) -> bool {
-        let rollback = ply_from_null.min(self.board.halfmoves);
-
         self.history
             .iter()
             .rev() // step through history in reverse
-            .take(rollback + 1) // only check elements in the rollback
+            .take(ply_from_null + 1) // only check elements until the previous null move
             .skip(1) // first element is opponent, skip.
             .step_by(2) // don't check opponent moves
             .any(|b| b.hash == self.board.hash) // stop at first repetition

--- a/src/tools/datagen.rs
+++ b/src/tools/datagen.rs
@@ -165,7 +165,7 @@ fn datagen_thread(id: usize, games: usize, tc: TimeControl, path: &Path) {
             }
 
             tt.increment_age();
-            thread.advance_ply(1);
+            thread.advance_ply(1, position.board.halfmoves);
             thread.clock = Clock::new(
                 Arc::new(AtomicBool::new(false)),
                 Arc::new(AtomicU64::new(0)),


### PR DESCRIPTION
Fix major repetition detection bug which was evident in CCC testing.

[STC NO DRAW ADJ](https://chess.swehosting.se/test/3512/):
```
ELO   | 4.32 +- 5.42 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-5.00, 0.00]
GAMES | N: 7552 W: 1855 L: 1761 D: 3936
```