### PR TITLE
Use a smaller max value for standard histories

### DIFF
--- a/src/engine/move_picker.rs
+++ b/src/engine/move_picker.rs
@@ -250,8 +250,6 @@ const LVA: [i32; PIECE_COUNT] = [5, 5, 4, 4, 3, 3, 2, 2, 1, 1, 0, 0];
 const PROMO_SCORE: i32 = 70; // Queen promotions have best MVV-LVA value, but still less than good tacticals
 const EP_SCORE: i32 = 15; // EP equal to pxp
 
-pub const HISTORY_MAX: i32 = 49152; // Quiet moves have scores between +- 49152
-
 /// Score a single tactical move. These moves are either captures or queen promotions.
 fn score_tactical(m: Move, see_threshold: Eval, board: &Board) -> i32 {
     // Underpromotions get the worst score

--- a/src/engine/search_params.rs
+++ b/src/engine/search_params.rs
@@ -12,6 +12,10 @@ pub const INFINITY: Eval = 32001; // score upper bound
 pub const MATE: Eval = 32000; // mate in 0 moves
 pub const MATE_IN_PLY: Eval = MATE - MAX_DEPTH as Eval; // mate in x moves
 
+pub const HIST_MAX: i32 = 8192;
+pub const CONT_HIST_MAX: i32 = 16384;
+pub const HISTORY_MAX: i32 = HIST_MAX + 2 * CONT_HIST_MAX;
+
 pub const TT_REPLACE_OFFSET: usize = 11;
 
 pub const ASPIRATION_LOWER_LIMIT: usize = 5;

--- a/src/engine/thread.rs
+++ b/src/engine/thread.rs
@@ -24,9 +24,9 @@ pub struct Thread {
 
     // Move ordering
     pub killer_moves: [[Move; 2]; MAX_DEPTH],
-    history: HistoryTable,
-    counter_moves: DoubleHistoryTable,
-    followup_moves: DoubleHistoryTable,
+    history: HistoryTable::<HIST_MAX>,
+    counter_moves: ContinuationHistoryTable::<CONT_HIST_MAX>,
+    followup_moves: ContinuationHistoryTable::<CONT_HIST_MAX>,
 
     // Search stats
     pub nodes: u64,
@@ -84,8 +84,8 @@ impl Thread {
 
             killer_moves: [[NULL_MOVE; 2]; MAX_DEPTH],
             history: HistoryTable::default(),
-            counter_moves: DoubleHistoryTable::default(),
-            followup_moves: DoubleHistoryTable::default(),
+            counter_moves: ContinuationHistoryTable::default(),
+            followup_moves: ContinuationHistoryTable::default(),
 
             nodes: 0,
             seldepth: 0,


### PR DESCRIPTION
Cap standard history to 8192 and conthists at 16384.

[STC](https://chess.swehosting.se/test/3516/):
```
ELO   | 6.83 +- 4.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 13584 W: 3434 L: 3167 D: 6983
```