### PR TITLE
QS Draws

### DIFF
--- a/carp/src/search.rs
+++ b/carp/src/search.rs
@@ -489,6 +489,11 @@ impl Position {
             return self.evaluate();
         }
 
+        // Stop searching if the position is a rule-based draw
+        if self.is_draw(t.ply_from_null) {
+            return 0;
+        }
+
         let in_check = self.king_in_check();
 
         // Probe the TT and if possible get a tt move


### PR DESCRIPTION
The test has positive LLR on (0,3) and shows at least non-regression, no point in further testing something so simple.

[STC](https://chess.swehosting.se/test/3541/):
```
ELO   | 1.24 +- 2.44 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -1.31 (-2.25, 2.89) [0.00, 5.00]
GAMES | N: 36544 W: 8680 L: 8550 D: 19314
```