### PR TITLE
QS promos

### DIFF
--- a/carp/src/move_picker.rs
+++ b/carp/src/move_picker.rs
@@ -320,7 +320,7 @@ impl<const QUIETS: bool> MovePicker<QUIETS> {
 mod tests {
     use super::*;
     use chess::{
-        board::{CAPTURES, QUIETS},
+        board::{TACTICALS, QUIETS},
         piece::Color,
         square::Square,
     };
@@ -367,13 +367,13 @@ mod tests {
     #[test]
     fn test_capture_picker() {
         let b: Board = "2r1k3/1P6/8/8/5b2/6P1/P7/2Q3K1 w - - 0 1".parse().unwrap();
-        let move_list = b.gen_moves::<CAPTURES>();
+        let move_list = b.gen_moves::<TACTICALS>();
         let move_count = move_list.len();
 
         let tt_move = Move::new(Square::A2, Square::A4, MoveType::DoublePush);
         let good_cap = Move::new(Square::B7, Square::C8, MoveType::QueenCapPromo);
 
-        let mut picker = MovePicker::<CAPTURES>::new(move_list, Some(tt_move), 0);
+        let mut picker = MovePicker::<TACTICALS>::new(move_list, Some(tt_move), 0);
         let t = Thread::fixed_depth(0);
 
         println!("{b}");

--- a/carp/src/search.rs
+++ b/carp/src/search.rs
@@ -15,7 +15,7 @@ use crate::{
     tt::{TTFlag, TT},
 };
 use chess::{
-    board::{CAPTURES, QUIETS},
+    board::{TACTICALS, QUIETS},
     moves::Move,
 };
 
@@ -594,7 +594,7 @@ impl Position {
 
         let mut best_move = Move::NULL;
         let mut best_eval = stand_pat;
-        let mut picker = self.gen_moves::<CAPTURES>(tt_move, 0);
+        let mut picker = self.gen_moves::<TACTICALS>(tt_move, 0);
 
         // The capture picker implicitly prunes bad SEE moves
         while let Some((m, _)) = picker.next(&self.board, t) {


### PR DESCRIPTION
Generate queen promotions in QS.

[STC](https://chess.swehosting.se/test/3769/):
```
ELO   | 3.39 +- 2.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 32960 W: 7932 L: 7610 D: 17418
```