### PR TITLE
Caphist

### DIFF
--- a/carp/src/search.rs
+++ b/carp/src/search.rs
@@ -15,7 +15,7 @@ use crate::{
     tt::{TTFlag, TT},
 };
 use chess::{
-    board::{TACTICALS, QUIETS},
+    board::{QUIETS, TACTICALS},
     moves::Move,
 };
 
@@ -332,7 +332,8 @@ impl Position {
         let old_alpha = alpha;
         let mut best_move = Move::NULL;
         let mut best_eval = -INFINITY;
-        let mut searched_quiets = Vec::with_capacity(20);
+        let mut caps_tried = Vec::with_capacity(20);
+        let mut quiets_tried = Vec::with_capacity(20);
         let mut move_count = 0;
 
         #[cfg(not(feature = "datagen"))]
@@ -479,18 +480,18 @@ impl Position {
                 }
 
                 if eval >= beta {
-                    if is_quiet {
-                        t.update_tables(m, depth, self.board.side, searched_quiets);
-                    };
-
+                    t.update_tables(m, depth, &self.board, quiets_tried, caps_tried);
                     alpha = beta;
+                    
                     break;
                 }
             }
 
-            // save searched quiets that didn't cause a cutoff for negative history score
+            // Save moves that didn't cutoff for negative history bonuses
             if is_quiet {
-                searched_quiets.push(m);
+                quiets_tried.push(m);
+            } else if m.get_type().is_capture() {
+                caps_tried.push(m);
             }
 
             move_count += 1;

--- a/carp/src/search_params.rs
+++ b/carp/src/search_params.rs
@@ -18,6 +18,9 @@ pub const HIST_MAX: i32 = 8192;
 pub const CONT_HIST_MAX: i32 = 16384;
 pub const CAP_HIST_MAX: i32 = 16384;
 pub const HISTORY_MAX: i32 = HIST_MAX + 2 * CONT_HIST_MAX;
+pub const HISTORY_MAX_BONUS: i16 = 1600;
+pub const HISTORY_FACTOR: i16 = 350;
+pub const HISTORY_OFFSET: i16 = 350;
 
 pub const TT_REPLACE_OFFSET: usize = 11;
 

--- a/carp/src/search_params.rs
+++ b/carp/src/search_params.rs
@@ -16,6 +16,7 @@ pub const LONGEST_TB_MATE: Eval = TB_MATE - MAX_DEPTH as Eval; // tb win in x mo
 
 pub const HIST_MAX: i32 = 8192;
 pub const CONT_HIST_MAX: i32 = 16384;
+pub const CAP_HIST_MAX: i32 = 16384;
 pub const HISTORY_MAX: i32 = HIST_MAX + 2 * CONT_HIST_MAX;
 
 pub const TT_REPLACE_OFFSET: usize = 11;

--- a/carp/src/search_tables.rs
+++ b/carp/src/search_tables.rs
@@ -53,7 +53,7 @@ type CaptureHistory = [[[i16; Piece::COUNT - 1]; Square::COUNT]; Piece::TOTAL];
 
 /// History bonus is Stockfish's "gravity"
 pub fn history_bonus(depth: usize) -> i16 {
-    400.min(depth * depth) as i16
+    HISTORY_MAX_BONUS.min(HISTORY_FACTOR * depth as i16 - HISTORY_OFFSET)
 }
 
 /// Taper history so that it's bounded to +-MAX
@@ -65,7 +65,7 @@ const fn taper_bonus<const MAX: i32>(bonus: i16, old: i16) -> i16 {
     let b = bonus as i32;
 
     // Use i32's to avoid overflows
-    (o + 8 * b - (o * b.abs()) / (MAX / 8)) as i16
+    (o + b - (o * b.abs()) / MAX) as i16
 }
 
 /// Simple history tables are used for standard move histories.

--- a/carp/src/search_tables.rs
+++ b/carp/src/search_tables.rs
@@ -3,6 +3,7 @@
 ///    - PV Table: holds the principal variation, which is the main line the engine predicts
 use crate::search_params::*;
 use chess::{
+    board::Board,
     moves::Move,
     piece::{Color, Piece},
     square::Square,
@@ -48,6 +49,7 @@ impl PVTable {
 
 type History = [[[i16; Square::COUNT]; Square::COUNT]; 2];
 type ContinuationHistory = [[[[i16; Square::COUNT]; Square::COUNT]; Square::COUNT]; Piece::TOTAL];
+type CaptureHistory = [[[i16; Piece::COUNT - 1]; Square::COUNT]; Piece::TOTAL];
 
 /// History bonus is Stockfish's "gravity"
 pub fn history_bonus(depth: usize) -> i16 {
@@ -82,11 +84,15 @@ impl<const MAX: i32> Default for HistoryTable<MAX> {
 }
 
 impl<const MAX: i32> HistoryTable<MAX> {
+    /// Get an index for the given move.
+    fn index(m: Move, side: Color) -> (usize, usize, usize) {
+        (side as usize, m.get_src() as usize, m.get_tgt() as usize)
+    }
+
     /// Add a history bonus value to the given move.
     fn add_bonus(&mut self, bonus: i16, m: Move, side: Color) {
-        let src = m.get_src() as usize;
-        let tgt = m.get_tgt() as usize;
-        let old = &mut self.history[side as usize][src][tgt];
+        let index = Self::index(m, side);
+        let old = &mut self.history[index.0][index.1][index.2];
 
         *old = taper_bonus::<MAX>(bonus, *old);
     }
@@ -102,10 +108,9 @@ impl<const MAX: i32> HistoryTable<MAX> {
 
     /// Get the history score for a given move by the given side.
     pub fn get_score(&self, m: Move, side: Color) -> i32 {
-        let src = m.get_src() as usize;
-        let tgt = m.get_tgt() as usize;
+        let index = Self::index(m, side);
 
-        self.history[side as usize][src][tgt] as i32
+        self.history[index.0][index.1][index.2] as i32
     }
 }
 
@@ -143,11 +148,20 @@ impl<const MAX: i32> Default for ContinuationHistoryTable<MAX> {
 }
 
 impl<const MAX: i32> ContinuationHistoryTable<MAX> {
+    /// Get an index for the given move.
+    fn index(m: Move, prev_piece: Piece, prev_tgt: Square) -> (usize, usize, usize, usize) {
+        (
+            prev_piece as usize,
+            prev_tgt as usize,
+            m.get_src() as usize,
+            m.get_tgt() as usize,
+        )
+    }
+
     /// Add a history bonus value to the given move.
-    fn add_bonus(&mut self, bonus: i16, m: Move, p: usize, t: usize) {
-        let src = m.get_src() as usize;
-        let tgt = m.get_tgt() as usize;
-        let old = &mut self.history[p][t][src][tgt];
+    fn add_bonus(&mut self, bonus: i16, m: Move, prev_piece: Piece, prev_tgt: Square) {
+        let index = Self::index(m, prev_piece, prev_tgt);
+        let old = &mut self.history[index.0][index.1][index.2][index.3];
 
         *old = taper_bonus::<MAX>(bonus, *old);
     }
@@ -156,16 +170,69 @@ impl<const MAX: i32> ContinuationHistoryTable<MAX> {
     /// Gives a positive bonus to the fail-high move and a negative bonus to all other moves tried.
     pub fn update(&mut self, bonus: i16, best: Move, p: Piece, tgt: Square, searched: &Vec<Move>) {
         for m in searched {
-            self.add_bonus(-bonus, *m, p as usize, tgt as usize);
+            self.add_bonus(-bonus, *m, p, tgt);
         }
-        self.add_bonus(bonus, best, p as usize, tgt as usize);
+        self.add_bonus(bonus, best, p, tgt);
     }
 
     /// Get the double history score for a given move
-    pub fn get_score(&self, m: Move, p: Piece, prev_tgt: Square) -> i32 {
-        let src = m.get_src() as usize;
-        let tgt = m.get_tgt() as usize;
+    pub fn get_score(&self, m: Move, prev_piece: Piece, prev_tgt: Square) -> i32 {
+        let index = Self::index(m, prev_piece, prev_tgt);
 
-        self.history[p as usize][prev_tgt as usize][src][tgt] as i32
+        self.history[index.0][index.1][index.2][index.3] as i32
+    }
+}
+
+/// History tables used for captures.
+///     Indexing: [capturing piece][tgt][captured piece]
+#[derive(Clone, Debug)]
+pub struct CaptureHistoryTable<const MAX: i32> {
+    history: CaptureHistory,
+}
+
+impl<const MAX: i32> Default for CaptureHistoryTable<MAX> {
+    fn default() -> Self {
+        Self {
+            history: [[[0; Piece::COUNT - 1]; Square::COUNT]; Piece::TOTAL],
+        }
+    }
+}
+
+impl<const MAX: i32> CaptureHistoryTable<MAX> {
+    /// Get an index for the given move.
+    fn index(m: Move, board: &Board) -> (usize, usize, usize) {
+        (
+            board.piece_at(m.get_src()) as usize,
+            m.get_tgt() as usize,
+            board.get_capture(m).index(),
+        )
+    }
+
+    /// Add a history bonus value to the given move.
+    fn add_bonus(&mut self, bonus: i16, m: Move, board: &Board) {
+        let index = Self::index(m, board);
+        let old = &mut self.history[index.0][index.1][index.2];
+
+        *old = taper_bonus::<MAX>(bonus, *old);
+    }
+
+    /// Update the history table after a beta cutoff.
+    /// Gives a positive bonus to the fail-high move and a negative bonus to all other moves tried.
+    /// Can be called with a non-capture move to only give negative bonuses.
+    pub fn update(&mut self, bonus: i16, best: Move, board: &Board, searched: &Vec<Move>) {
+        for m in searched {
+            self.add_bonus(-bonus, *m, board);
+        }
+
+        if best.get_type().is_capture() {
+            self.add_bonus(bonus, best, board);
+        }
+    }
+
+    /// Get the double history score for a given move
+    pub fn get_score(&self, m: Move, board: &Board) -> i32 {
+        let index = Self::index(m, board);
+
+        self.history[index.0][index.1][index.2] as i32
     }
 }

--- a/chess/src/board.rs
+++ b/chess/src/board.rs
@@ -317,6 +317,15 @@ impl Board {
         self.piece[square as usize].unwrap()
     }
 
+    /// Returns the piece being captured by the move.
+    pub fn get_capture(&self, m: Move) -> Piece {
+        if m.get_type() == MoveType::EnPassant {
+            (!self.side).pawn()
+        } else {
+            self.piece_at(m.get_tgt())
+        }
+    }
+
     /// Mask all attackers of a certain square, given the blocker bitboard.
     fn attackers(&self, square: Square, blockers: BitBoard) -> BitBoard {
         self.opp_occupancy()


### PR DESCRIPTION
Use Capture Histories for capture ordering, replacing the LVA value. This initially lost, but correcting the history bonus formula lead to massive gains. Then the individual history bonus change was tested against this and showed that it actually interacted really well with capture histories.

First is the test with both changes against dev
[STC](https://chess.swehosting.se/test/3784/):
```
ELO   | 25.03 +- 10.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 5.00]
GAMES | N: 2016 W: 537 L: 392 D: 1087
```

Then is the test of only using the history bonus change vs also doing caphist (hence, H0 is caphist being better)
[STC](https://chess.swehosting.se/test/3786/):
```
ELO   | -9.92 +- 8.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.34 (-2.25, 2.89) [0.00, 5.00]
GAMES | N: 3152 W: 700 L: 790 D: 1662
```