### PR TITLE
Sane Replacement

### DIFF
--- a/carp/src/search.rs
+++ b/carp/src/search.rs
@@ -586,9 +586,7 @@ impl Position {
         };
 
         // Stand pat pruning
-        let old_alpha = alpha;
         alpha = alpha.max(stand_pat);
-
         if stand_pat >= beta {
             return stand_pat;
         }
@@ -632,8 +630,6 @@ impl Position {
         if !t.stop {
             let tt_flag = if best_eval >= beta {
                 TTFlag::Lower
-            } else if best_eval > old_alpha {
-                TTFlag::Exact
             } else {
                 TTFlag::Upper
             };

--- a/carp/src/search_params.rs
+++ b/carp/src/search_params.rs
@@ -17,14 +17,14 @@ pub const LONGEST_TB_MATE: Eval = TB_MATE - MAX_DEPTH as Eval; // tb win in x mo
 pub const HIST_MAX: i32 = 8192;
 pub const CONT_HIST_MAX: i32 = 16384;
 pub const CAP_HIST_MAX: i32 = 16384;
-pub const CONT_HIST_COUNT: usize = 4;
+pub const CONT_HIST_COUNT: usize = 2;
 pub const HISTORY_MAX: i32 = HIST_MAX + CONT_HIST_MAX * CONT_HIST_COUNT as i32;
 
 pub const HISTORY_MAX_BONUS: i16 = 1600;
 pub const HISTORY_FACTOR: i16 = 350;
 pub const HISTORY_OFFSET: i16 = 350;
 
-pub const TT_REPLACE_OFFSET: usize = 11;
+pub const TT_REPLACE_OFFSET: usize = 4;
 
 pub const ASPIRATION_LOWER_LIMIT: usize = 5;
 pub const ASPIRATION_WINDOW: Eval = 25;

--- a/carp/src/search_params.rs
+++ b/carp/src/search_params.rs
@@ -17,7 +17,9 @@ pub const LONGEST_TB_MATE: Eval = TB_MATE - MAX_DEPTH as Eval; // tb win in x mo
 pub const HIST_MAX: i32 = 8192;
 pub const CONT_HIST_MAX: i32 = 16384;
 pub const CAP_HIST_MAX: i32 = 16384;
-pub const HISTORY_MAX: i32 = HIST_MAX + 2 * CONT_HIST_MAX;
+pub const CONT_HIST_COUNT: usize = 4;
+pub const HISTORY_MAX: i32 = HIST_MAX + CONT_HIST_MAX * CONT_HIST_COUNT as i32;
+
 pub const HISTORY_MAX_BONUS: i16 = 1600;
 pub const HISTORY_FACTOR: i16 = 350;
 pub const HISTORY_OFFSET: i16 = 350;
@@ -62,5 +64,3 @@ pub const LMP_BASE: usize = 4;
 pub const SEE_PRUNING_THRESHOLD: usize = 9;
 pub const SEE_CAPTURE_MARGIN: Eval = -20;
 pub const SEE_QUIET_MARGIN: Eval = -65;
-
-pub const PIECE_VALUES: [Eval; 12] = [161, 161, 446, 446, 464, 464, 705, 705, 1322, 1322, 0, 0];


### PR DESCRIPTION
Reduce the really high depth bonus given when replacing tt entries. Also adds some non-functional refactoring for history scoring allowing for an arbitrary amount of continuation histories.

[STC](https://chess.swehosting.se/test/3799/):
```
ELO   | 8.37 +- 4.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 10384 W: 2524 L: 2274 D: 5586
```