### PR TITLE
Remove killers

### DIFF
--- a/carp-tools/src/datagen.rs
+++ b/carp-tools/src/datagen.rs
@@ -182,7 +182,7 @@ fn datagen_thread(id: usize, games: usize, tc: TimeControl, tb: TB, path: &Path)
             }
 
             tt.increment_age();
-            thread.advance_ply(1, position.ply(), position.board.halfmoves);
+            thread.clear_for_search(position.ply(), position.board.halfmoves);
             thread.clock = Clock::new(
                 Arc::new(AtomicBool::new(false)),
                 Arc::new(AtomicU64::new(0)),

--- a/carp/src/move_picker.rs
+++ b/carp/src/move_picker.rs
@@ -200,7 +200,7 @@ impl<const QUIETS: bool> MovePicker<QUIETS> {
 }
 
 // TT Score must be greater than all other move values.
-// Tactical scoring: [1_000_000-2_000_000] + [0-2400-4800-9600] +- (0:16_384) +- [0-26384]
+// Tactical scoring: [1_000_000-2_000_000] + [0-2400-4800-9600] +- (0:16_384) + [0-26384]
 pub const TT_SCORE: i32 = i32::MAX;
 pub const GOOD_TACTICAL: i32 = 2_000_000;
 const BAD_TACTICAL: i32 = 1_000_000;
@@ -213,7 +213,7 @@ fn score_tactical(m: Move, see_threshold: Eval, board: &Board, thread: &Thread) 
     let score = match m.get_type() {
         MoveType::QueenCapPromo => return GOOD_TACTICAL + PROMO_SCORE,
         MoveType::QueenPromotion => PROMO_SCORE,
-        t if t.is_underpromotion() => return BAD_TACTICAL - PROMO_SCORE,
+        t if t.is_underpromotion() => return BAD_TACTICAL,
         _ => MVV[board.get_capture(m).index()] + thread.score_cap_hist(m, board),
     };
 
@@ -300,7 +300,7 @@ mod tests {
         assert_eq!(moves[5].0, good_quiet);
         assert_eq!(moves[26].0, bad_quiet);
         assert_eq!(moves[27].0, bad_promo);
-        assert_eq!(moves[28].1, BAD_TACTICAL - PROMO_SCORE);
+        assert_eq!(moves[28].1, BAD_TACTICAL);
     }
 
     #[test]

--- a/carp/src/move_picker.rs
+++ b/carp/src/move_picker.rs
@@ -14,8 +14,6 @@ pub enum Stage {
     TTMove,
     ScoreTacticals,
     GoodTacticals,
-    Killer1,
-    Killer2,
     ScoreQuiets,
     Quiets,
     BadTacticals,
@@ -27,20 +25,19 @@ pub enum Stage {
 ///
 /// In the end, the move list ends up structured as follows:
 ///
-///                                                   v quiet_index
-/// +--------------------------------------------------------------------------+
-/// | TT MOVE | GOOD TACTICALS |  KILLER 1 | KILLER 2 | QUIETS | BAD TACTICALS |
-/// +--------------------------------------------------------------------------+
-///                            ^ good_tactical_index           ^ bad_tactical_index
+///                             v quiet_index
+/// +----------------------------------------------------+
+/// | TT MOVE | GOOD TACTICALS  | QUIETS | BAD TACTICALS |
+/// +----------------------------------------------------+
+///                                      ^ bad_tactical_index
 #[derive(Clone, Debug)]
 pub struct MovePicker<const QUIETS: bool> {
     move_list: MoveList,
     scores: [i32; MoveList::SIZE],
-    index: usize,               // Index used for movelist traversal
-    good_tactical_index: usize, // Index of the first non-tactical move
-    bad_tactical_index: usize,  // Index of the first bad tactical move
-    quiet_index: usize,         // Index of the first non-killer quiet move
-    pub stage: Stage,           // Stage is not totally accurate externally, use move scores
+    index: usize,              // Index used for movelist traversal
+    quiet_index: usize,        // Index of the first non-killer quiet move
+    bad_tactical_index: usize, // Index of the first bad tactical move
+    pub stage: Stage,          // Stage is not totally accurate externally, use move scores
     tt_move: Option<Move>,
     pub skip_quiets: bool,
     see_threshold: Eval,
@@ -68,9 +65,8 @@ impl<const QUIETS: bool> MovePicker<QUIETS> {
             move_list,
             scores: [0; MoveList::SIZE],
             index: 0,
-            good_tactical_index: 0,
-            bad_tactical_index,
             quiet_index: 0,
+            bad_tactical_index,
             stage,
             tt_move,
             skip_quiets: false,
@@ -81,7 +77,7 @@ impl<const QUIETS: bool> MovePicker<QUIETS> {
     /// Fetch the next best move from the move list along with a move score.
     /// Note that most of the logic here is "fall through" where a stage may quietly pass without
     /// yielding a move (e.g. all scoring stages)
-    pub fn next(&mut self, board: &Board, t: &Thread) -> Option<(Move, i32)> {
+    pub fn next(&mut self, board: &Board, thread: &Thread) -> Option<(Move, i32)> {
         if self.stage == Stage::Done {
             return None;
         }
@@ -100,66 +96,29 @@ impl<const QUIETS: bool> MovePicker<QUIETS> {
         // Assign a score to all captures/queen promotions and move them to the front.
         if self.stage == Stage::ScoreTacticals {
             self.stage = Stage::GoodTacticals;
-            self.score_tacticals(board, t);
+            self.score_tacticals(board, thread);
         }
 
         // Yield all captures/queen promotions with a positive SEE
         if self.stage == Stage::GoodTacticals {
-            if let Some((m, s)) = self.partial_sort(self.good_tactical_index) {
+            if let Some((m, s)) = self.partial_sort(self.quiet_index) {
                 return Some((m, s));
             }
 
             // In QSearch we implicitly skip all captures with negative SEE and underpromotions.
             if QUIETS {
-                self.stage = Stage::Killer1;
+                self.stage = Stage::ScoreQuiets;
             } else {
                 self.stage = Stage::Done;
                 return None;
             }
         }
 
-        // Lazily look for the first killer move (if we are not skipping quiets)
-        if self.stage == Stage::Killer1 {
-            self.stage = Stage::Killer2;
-
-            let k1 = t.killer_moves[t.ply][0];
-            if !self.skip_quiets && k1 != Move::NULL && self.tt_move != Some(k1) {
-                let killer = self.find_pred(self.quiet_index, self.bad_tactical_index, |m| m == k1);
-
-                if let Some(m) = killer {
-                    self.quiet_index += 1;
-                    return Some((m, KILLER1));
-                }
-            }
-        }
-
-        // Lazily look for the second killer move (if we are not skipping quiets)
-        if self.stage == Stage::Killer2 {
-            // If we are skipping quiets, we can just move to bad tacticals
-            if !self.skip_quiets {
-                self.stage = Stage::ScoreQuiets;
-            } else {
-                self.stage = Stage::BadTacticals;
-                self.index = self.bad_tactical_index;
-            }
-
-            let k2 = t.killer_moves[t.ply][1];
-            if !self.skip_quiets && k2 != Move::NULL && self.tt_move != Some(k2) {
-                let killer = self.find_pred(self.quiet_index, self.bad_tactical_index, |m| m == k2);
-
-                if let Some(m) = killer {
-                    self.quiet_index += 1;
-                    return Some((m, KILLER2));
-                }
-            }
-        }
-
         // Assign a history score to all quiet moves
         if self.stage == Stage::ScoreQuiets {
             self.stage = Stage::Quiets;
-            self.index = self.quiet_index; // skip over killers
 
-            t.assign_history_scores(
+            thread.assign_history_scores(
                 board.side,
                 &self.move_list.moves[self.index..self.bad_tactical_index],
                 &mut self.scores[self.index..self.bad_tactical_index],
@@ -240,28 +199,21 @@ impl<const QUIETS: bool> MovePicker<QUIETS> {
     }
 }
 
-/// Special move scoring. We make sure these scores are much higher than any history score
+// TT Score must be greater than all other move values.
+// Tactical scoring: [1_000_000-2_000_000] + [0-2400-4800-9600] +- (0:16_384) +- [0-26384]
 pub const TT_SCORE: i32 = i32::MAX;
-pub const KILLER1: i32 = GOOD_TACTICAL + 2;
-pub const KILLER2: i32 = GOOD_TACTICAL + 1;
-
-/// Tactical scoring: [1.000.000-2.000.000] +- 16_384 + [0/70_000]
 pub const GOOD_TACTICAL: i32 = 2_000_000;
-pub const BAD_TACTICAL: i32 = 1_000_000;
-const PROMO_SCORE: i32 = 70_000; // Queen promotions have best MVV + CapHist value, but still less than good tacticals
+const BAD_TACTICAL: i32 = 1_000_000;
+const PROMO_SCORE: i32 = CAP_HIST_MAX + MVV[4] + 1; // Queen promotions have best MVV + CapHist value
 const MVV: [i32; Piece::COUNT] = [0, 2400, 2400, 4800, 9600, 0];
 
 /// Score a single tactical move. These moves are either captures or queen promotions.
 fn score_tactical(m: Move, see_threshold: Eval, board: &Board, thread: &Thread) -> i32 {
-    // Underpromotions get the worst score
-    if m.get_type().is_underpromotion() {
-        return BAD_TACTICAL;
-    }
-
     // Enpassant/QueenCapPromo are always good
     let score = match m.get_type() {
         MoveType::QueenCapPromo => return GOOD_TACTICAL + PROMO_SCORE,
         MoveType::QueenPromotion => PROMO_SCORE,
+        t if t.is_underpromotion() => return BAD_TACTICAL - PROMO_SCORE,
         _ => MVV[board.get_capture(m).index()] + thread.score_cap_hist(m, board),
     };
 
@@ -279,7 +231,7 @@ impl<const QUIETS: bool> MovePicker<QUIETS> {
     /// Good tacticals are moved to the front of the list, bad tacticals to the back.
     fn score_tacticals(&mut self, board: &Board, thread: &Thread) {
         let mut i = self.index;
-        self.good_tactical_index = self.index;
+        self.quiet_index = self.index;
 
         while i < self.bad_tactical_index {
             let m = self.move_list.moves[i];
@@ -288,9 +240,9 @@ impl<const QUIETS: bool> MovePicker<QUIETS> {
                 let score = score_tactical(m, self.see_threshold, board, thread);
 
                 if score >= GOOD_TACTICAL {
-                    self.move_list.moves.swap(i, self.good_tactical_index);
-                    self.scores[self.good_tactical_index] = score;
-                    self.good_tactical_index += 1;
+                    self.move_list.moves.swap(i, self.quiet_index);
+                    self.scores[self.quiet_index] = score;
+                    self.quiet_index += 1;
                     i += 1;
                 } else {
                     self.bad_tactical_index -= 1;
@@ -301,8 +253,6 @@ impl<const QUIETS: bool> MovePicker<QUIETS> {
                 i += 1;
             }
         }
-
-        self.quiet_index = self.good_tactical_index; // quiets start after killers
     }
 }
 
@@ -322,35 +272,35 @@ mod tests {
 
         let tt_move = Move::new(Square::A2, Square::A4, MoveType::DoublePush);
         let good_cap = Move::new(Square::B7, Square::C8, MoveType::QueenCapPromo);
-        let bad_promo = Move::new(Square::B7, Square::B8, MoveType::QueenPromotion);
-        let k1 = Move::new(Square::A2, Square::A3, MoveType::Quiet);
-        let k2 = Move::new(Square::A2, Square::A8, MoveType::Quiet); // impossible move
         let good_quiet = Move::new(Square::C1, Square::F1, MoveType::Quiet);
         let bad_quiet = Move::new(Square::G1, Square::H2, MoveType::Quiet);
+        let bad_promo = Move::new(Square::B7, Square::B8, MoveType::QueenPromotion);
 
         let mut picker = MovePicker::<QUIETS>::new(move_list, Some(tt_move), 0);
         let mut t = Thread::fixed_depth(0);
-
         t.update_tables(good_quiet, 10, &Board::default(), vec![bad_quiet], vec![]);
-        t.killer_moves[t.ply][0] = k1;
-        t.killer_moves[t.ply][1] = k2; // impossible move
 
         println!("{b}");
 
         let mut moves = Vec::new();
         while let Some(m) = picker.next(&b, &t) {
-            println!("{:?} -- Move: {} Score: {}", picker.stage, m.0, m.1);
+            println!(
+                "{:?} -- Move {}: {} Score: {}",
+                picker.stage,
+                moves.len(),
+                m.0,
+                m.1
+            );
             moves.push(m);
         }
 
         assert_eq!(moves.len(), move_count);
         assert_eq!(moves[0].0, tt_move);
         assert_eq!(moves[1].0, good_cap);
-        assert_eq!(moves[5].0, k1);
-        assert_eq!(moves[6].0, good_quiet);
+        assert_eq!(moves[5].0, good_quiet);
         assert_eq!(moves[26].0, bad_quiet);
         assert_eq!(moves[27].0, bad_promo);
-        assert_eq!(moves[28].1, BAD_TACTICAL);
+        assert_eq!(moves[28].1, BAD_TACTICAL - PROMO_SCORE);
     }
 
     #[test]

--- a/carp/src/search.rs
+++ b/carp/src/search.rs
@@ -428,10 +428,11 @@ impl Position {
                         r -= in_check as i32; // reduce less when in check
                         r -= is_check as i32; // reduce less when giving check
 
+                        // flat reduction/extension based on history
                         if s > HISTORY_MAX / 2 {
-                            r -= 1; // Reduce less high history moves/killers
+                            r -= 1;
                         } else if s < -HISTORY_MAX / 2 {
-                            r += 1; // Reduce more low history moves
+                            r += 1;
                         }
 
                         r.clamp(1, (depth - 1) as i32) as usize
@@ -482,7 +483,7 @@ impl Position {
                 if eval >= beta {
                     t.update_tables(m, depth, &self.board, quiets_tried, caps_tried);
                     alpha = beta;
-                    
+
                     break;
                 }
             }

--- a/readme.MD
+++ b/readme.MD
@@ -76,9 +76,9 @@ As of Carp 2.0, NNUE has compltely replaced the old HCE.
 * Fail-Hard Negamax + Quiescence
 * Iterative Deepening with Aspiration Windows
 * Move Ordering with a staged sorter:
-  - MVV-LVA with Threshold Static Exchange Evaluation
-  - Killers
-  - History / Counter Move History / Followup History
+  - MVV + Capture History with Threshold Static Exchange Evaluation
+  - Quiet History
+  - Continuation Histories
 * Multithreading with Lazy-SMP
 * Lockless Transposition table with aging
 * Principal Variation Search


### PR DESCRIPTION
Killers were accidentally not updated anymore when I introduced Capture Histories. Turns out Continuation Histories pretty much cover their functionality and they can simply be removed. Sadly this means the Capture History tests are not entirely accurate, though the ELO gain was substantial enough to be more than that solely provided by removing killers.

Entire killer removal vs the accidental removal (this is non-functional, just removing the unused killer code)
[STC-REG](https://chess.swehosting.se/test/3839/):
```
ELO   | -0.81 +- 2.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-5.00, 0.00]
GAMES | N: 47952 W: 10895 L: 11007 D: 26050
```

Updating the killer tables
[STC](https://chess.swehosting.se/test/3834/):
```
ELO   | -4.71 +- 6.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 5.00]
GAMES | N: 5456 W: 1223 L: 1297 D: 2936
```
[STC-REG](https://chess.swehosting.se/test/3857/):
```
ELO   | -3.52 +- 3.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.25 (-2.25, 2.89) [-5.00, 0.00]
GAMES | N: 20320 W: 4603 L: 4809 D: 10908
```