### PR TITLE
Fix eval scaling typo

### DIFF
--- a/engine/src/position.rs
+++ b/engine/src/position.rs
@@ -152,7 +152,7 @@ impl Position {
 
         #[rustfmt::skip]
         let total_material =
-            self.board.knights().count_bits() as Eval * PIECE_VALUES[Piece::WK as usize] +
+            self.board.knights().count_bits() as Eval * PIECE_VALUES[Piece::WN as usize] +
             self.board.bishops().count_bits() as Eval * PIECE_VALUES[Piece::WB as usize] +
             self.board.rooks().count_bits() as Eval   * PIECE_VALUES[Piece::WR as usize] +
             self.board.queens().count_bits() as Eval  * PIECE_VALUES[Piece::WQ as usize];


### PR DESCRIPTION
Fixes #68.

[STC-REG](https://chess.swehosting.se/test/12033/):
```
Elo   | 2.29 +- 3.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 12730 W: 3012 L: 2928 D: 6790
Penta | [112, 1506, 3045, 1590, 112]
```